### PR TITLE
feat: enable secured map services on localhost + a shareable dev site

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -1,0 +1,22 @@
+# Deploys the app to the DEV project's LIVE channel
+# (https://ut-dnr-ugs-geolmapportal-dev.web.app) as a stable, shareable internal-review site.
+#
+# Trunk-based, on-demand: run it manually from the Actions tab (Run workflow -> pick any
+# branch) whenever you want reviewers to see a build. master->prod and PR->preview are
+# unchanged. Reuses the existing dev service-account secret (already used by the PR-preview
+# workflow). The dev site calls the SAME prod getArcGISToken function and shared ArcGIS server
+# as prod; only the Origin/Referer differ, which the token function already honors for this URL.
+name: Deploy to Firebase Hosting (dev live)
+on:
+  workflow_dispatch:
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_DEV }}
+          channelId: live
+          projectId: ut-dnr-ugs-geolmapportal-dev

--- a/functions/index.js
+++ b/functions/index.js
@@ -140,10 +140,33 @@ exports.getArcGISToken = onCall({
     "https://ut-dnr-ugs-geolmapportal-prod.firebaseapp.com",
     "https://geomap.geology.utah.gov",
     "https://ut-dnr-ugs-geolmapportal-dev.web.app",
-    "https://ut-dnr-ugs-geolmapportal-dev.firebaseapp.com"
+    "https://ut-dnr-ugs-geolmapportal-dev.firebaseapp.com",
+    // dev PR preview channels: https://ut-dnr-ugs-geolmapportal-dev--<channel>-<hash>.web.app
+    /^https:\/\/ut-dnr-ugs-geolmapportal-dev--[a-z0-9-]+\.web\.app$/,
+    // local testing (static server / firebase emulator)
+    /^http:\/\/localhost(:\d+)?$/,
+    /^http:\/\/127\.0\.0\.1(:\d+)?$/
   ]
 }, async (request) => {
   try {
+    // Mint the token with a referer matching the *validated* calling origin. ArcGIS referer
+    // tokens are checked against each request's Referer header, so for the secured services to
+    // load from anywhere other than geomap (localhost, the dev channel, prod .web.app), the
+    // token's referer must equal that page's origin. Only origins on this allowlist are honored;
+    // anything else (including unknown/forged Origin headers) falls back to prod. NOTE: ephemeral
+    // PR-preview channels are intentionally excluded — their URLs are semi-public, and a
+    // preview-referer token would let anyone with the link read the unpublished data.
+    const ALLOWED_REFERERS = [
+      /^https:\/\/geomap\.geology\.utah\.gov$/,
+      /^https:\/\/ut-dnr-ugs-geolmapportal-(prod|dev)\.web\.app$/,
+      /^http:\/\/localhost(:\d+)?$/,
+      /^http:\/\/127\.0\.0\.1(:\d+)?$/
+    ];
+    const callerOrigin = ((request.rawRequest && request.rawRequest.headers && request.rawRequest.headers.origin) || '').trim();
+    const referer = ALLOWED_REFERERS.some(function (re) { return re.test(callerOrigin); })
+      ? callerOrigin
+      : 'https://geomap.geology.utah.gov';
+
     // Get credentials from Secret Manager
     const [usernameVersion] = await secretClient.accessSecretVersion({
       name: 'projects/ut-dnr-ugs-geolmapportal-prod/secrets/geolmap_user/versions/latest'
@@ -161,7 +184,7 @@ exports.getArcGISToken = onCall({
       username: username,
       password: password,
       client: 'referer',
-      referer: 'https://geomap.geology.utah.gov',
+      referer: referer,
       expiration: 60,
       f: 'json'
     });
@@ -197,7 +220,7 @@ exports.getArcGISToken = onCall({
     };
 
   } catch (error) {
-    logger.error('Error in getArcGISTokenR:', error);
+    logger.error('Error in getArcGISToken:', error);
     throw new HttpsError('internal', 'Internal server error');
   }
 });

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -850,9 +850,16 @@ const orientedImageryViewer = new OrientedImageryViewer({
         let lastm = map.findLayerById(last);
 
         //console.log('last map:', lastm, last);
-        view.whenLayerView(lastm).then(function(layerView) {
+        // guard: if the last requested layer isn't in the map (never added, or a secured
+        // layer that failed to load), findLayerById returns undefined and whenLayerView would
+        // reject with view:no-layerview-for-layer. Hide the loader instead of throwing.
+        if (lastm) {
+            view.whenLayerView(lastm)
+                .then(function () { $('.page-loading').hide(); })
+                .catch(function () { $('.page-loading').hide(); });
+        } else {
             $('.page-loading').hide();
-        });
+        }
     }
     
 //}); //end view.when


### PR DESCRIPTION
## Summary
Makes the **secured** GeolMap services (24k/100k — unpublished data) load from places other than prod, and stands up a shareable dev review site. Three changes:

- **`feat(token)`** — `getArcGISToken` now mints the ArcGIS token with a `referer` matching the *validated* calling origin (geomap, prod/dev `.web.app`, localhost, 127.0.0.1) instead of hardcoded geomap. Secured services validate the token's referer, so without this they only loaded on prod. Origins are matched against anchored regexes and fall back to prod, so a forged `Origin` can't mint an arbitrary-referer token. Ephemeral PR previews are deliberately excluded (semi-public URLs must not carry a token for unpublished data).
- **`fix(map)`** — guards `addMaps` so a missing/failed layerview hides the loader instead of throwing `view:no-layerview-for-layer`.
- **`ci`** — `workflow_dispatch` deploy of any branch to the dev project's live channel (`ut-dnr-ugs-geolmapportal-dev.web.app`). `master`→prod and PR→preview are unchanged.

## Why it's coherent across branches/master
CORS (`allowedOrigins`) and the token referer key on the **deployed URL, not the branch** — three fixed targets (prod=geomap, dev=dev.web.app, local=localhost), so any branch deployed to a target is covered identically.

## Activation steps (operational, not in this diff)
1. Deploy the function: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" firebase deploy --only functions:getArcGISToken`
2. Add `https://ut-dnr-ugs-geolmapportal-dev.web.app` to the ArcGIS Server `allowedOrigins` (one clean entry, no spaces).
3. After merge: Actions → "Deploy to Firebase Hosting (dev live)" → Run workflow.

## Reviewers
App-security review of the token change: no blockers; regexes anchored/fail-closed, injection neutralized by URLSearchParams. Residual risk accepted: referer tokens are forgeable by non-browser clients (pre-existing) — App Check is the future hardening.

## Test plan
- [ ] Function deployed; localhost:8008 renders the secured 24k/100k (no "Invalid Token")
- [ ] Dev URL added to allowedOrigins; dev site renders secured layers
- [ ] Prod (geomap) still renders everything
- [ ] PR preview still loads app + readout (geology backdrop not expected)