### PR TITLE
ci: dev review flow (auto-deploy dev branch + dev-site link on PRs)

### DIFF
--- a/.github/workflows/dev-pr-link.yml
+++ b/.github/workflows/dev-pr-link.yml
@@ -1,0 +1,24 @@
+# When a PR from `dev` into master is opened, post a link to the live dev review site so
+# reviewers can see the full-fidelity staging build (real geology) before it ships to prod.
+# The dev site is a stable URL kept current by the push:[dev] deploy, so one comment suffices.
+name: Link dev site on dev PR
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, reopened]
+permissions:
+  pull-requests: write
+jobs:
+  comment:
+    if: github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment dev site link
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr comment "$PR" --repo "$REPO" --body "Dev review site (live \`dev\` staging build, full geology): https://ut-dnr-ugs-geolmapportal-dev.web.app
+
+This reflects the latest push to \`dev\`."

--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -1,14 +1,19 @@
 # Deploys the app to the DEV project's LIVE channel
 # (https://ut-dnr-ugs-geolmapportal-dev.web.app) as a stable, shareable internal-review site.
 #
-# Trunk-based, on-demand: run it manually from the Actions tab (Run workflow -> pick any
-# branch) whenever you want reviewers to see a build. master->prod and PR->preview are
-# unchanged. Reuses the existing dev service-account secret (already used by the PR-preview
-# workflow). The dev site calls the SAME prod getArcGISToken function and shared ArcGIS server
-# as prod; only the Origin/Referer differ, which the token function already honors for this URL.
+# Triggers:
+#   - push to `dev`: every merge to the dev branch auto-publishes to the dev site (staging).
+#   - workflow_dispatch: also run it manually from the Actions tab against any branch.
+# master->prod and PR->preview are unchanged. Reuses the existing dev service-account secret
+# (already used by the PR-preview workflow). The dev site calls the SAME prod getArcGISToken
+# function and shared ArcGIS server as prod; only the Origin/Referer differ, which the token
+# function already honors for this URL.
 name: Deploy to Firebase Hosting (dev live)
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - dev
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Two small CI additions for the `dev` staging flow:

1. **Auto-deploy `dev`** — `push: [dev]` on the dev-live workflow, so every merge to `dev` publishes to `https://ut-dnr-ugs-geolmapportal-dev.web.app`. The manual `workflow_dispatch` button stays.
2. **Link the dev site on `dev`->`master` PRs** — a workflow that comments the dev-site URL when a `dev`->`master` PR opens, so reviewers get a one-click link to the full-fidelity staging build before it ships to prod.

## Setup after merge (ordering matters)
`push`/`pull_request` workflows read their file from the relevant branch, so create `dev` from `master` AFTER this merges and it inherits both:
```
git checkout -b dev origin/master && git push -u origin dev
```

## Resulting flow
feature -> PR into `dev` -> merge (auto-deploy to dev site) -> open `dev`->`master` PR (bot comments the dev link) -> review on the live dev site -> merge to prod. `master`->prod and PR->preview are unchanged.

## Prod impact
Workflow-file-only; merging fires `merge.yml` -> a no-op prod hosting redeploy (same `public/`).