### PR TITLE
fix(ci): dev->master PR shows the stable dev link (repair dev-pr-link + drop preview)

### DIFF
--- a/.github/workflows/dev-pr-link.yml
+++ b/.github/workflows/dev-pr-link.yml
@@ -19,6 +19,4 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          gh pr comment "$PR" --repo "$REPO" --body "Dev review site (live \`dev\` staging build, full geology): https://ut-dnr-ugs-geolmapportal-dev.web.app
-
-This reflects the latest push to \`dev\`."
+          gh pr comment "$PR" --repo "$REPO" --body "Dev review site (live dev staging build, full geology): https://ut-dnr-ugs-geolmapportal-dev.web.app"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,7 +6,9 @@ permissions:
   pull-requests: write
 jobs:
   build_and_preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    # skip the ephemeral preview channel for dev->master PRs: their review target is the
+    # stable dev site (which has geology), not a dynamic preview URL (which doesn't)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'dev' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What was broken
- The `dev-pr-link` workflow (added in #125) had an unindented line in its `run` block, which broke the YAML. GitHub couldn't parse it, so it logged a **startup failure on every push** and never posted the dev-site link.
- Separately, the existing PR-preview workflow posts an **ephemeral preview URL** on every PR — including `dev`->`master`. That URL is a dynamic `*.web.app` channel that ISN'T in the ArcGIS allowlist, so it shows **no geology** — misleading for a promotion review.

## Fix
- `dev-pr-link.yml`: single-line comment body (valid YAML; verified it parses).
- `firebase-hosting-pull-request.yml`: skip the preview for `head_ref == 'dev'`, so `dev`->`master` PRs get only the stable dev-site link.

## After merge
Propagate to `dev` (so the next `dev`->`master` PR uses the fixed file): `git merge master` into `dev`. I can do that. The current #126 already has the correct link posted manually.

Workflow-only change; merging fires a no-op prod hosting redeploy.