### PR TITLE
ci: group Dependabot + skip its preview + checkout v5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Groups Dependabot updates so you get one PR per ecosystem (version + security)
+# instead of a pile of individual ones. The preview workflow is also configured to
+# skip Dependabot PRs (they can't read repo secrets), so these arrive without a false
+# failing check. Nothing here auto-merges -- you still review and merge.
+version: 2
+updates:
+  # Production Cloud Functions deps
+  - package-ecosystem: npm
+    directory: /functions
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      functions:
+        applies-to: version-updates
+        patterns: ["*"]
+      functions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # Root dev / CI tooling (never ships)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      root-tooling:
+        applies-to: version-updates
+        patterns: ["*"]
+      root-tooling-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # GitHub Actions (keeps checkout / deploy actions current, incl. the Node 20 -> 24 moves)
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -18,7 +18,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,12 +6,13 @@ permissions:
   pull-requests: write
 jobs:
   build_and_preview:
-    # skip the ephemeral preview channel for dev->master PRs: their review target is the
-    # stable dev site (which has geology), not a dynamic preview URL (which doesn't)
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'dev' }}
+    # skip the ephemeral preview for: dev->master PRs (their review target is the stable
+    # dev site, not a dynamic preview URL), and Dependabot PRs (GitHub withholds secrets
+    # from them, so the deploy step would always fail with an empty service account)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'dev' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set Firebase config
         run: |
           echo "FIREBASE_SERVICE_ACCOUNT=FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_DEV" >> $GITHUB_ENV


### PR DESCRIPTION
## What
CI hygiene to stop the recurring Dependabot noise and start on the Node 20 deprecation. No production surface; respects the master review rule (nothing auto-merges).

- **`.github/dependabot.yml`** — groups updates into one PR per ecosystem (functions npm, root npm, github-actions), for both version and security updates. Turns "6 separate PRs" into a couple of grouped ones.
- **Skip preview for Dependabot** — `github.actor != 'dependabot[bot]'` on the preview job. GitHub withholds secrets from Dependabot PRs, so `action-hosting-deploy` always failed with an empty `firebaseServiceAccount` (the red X you saw on every one). Skipping is correct — they don't need a preview.
- **`actions/checkout@v4 -> v5`** (Node 24) in the 3 deploy workflows, ahead of the Node 20 runner decommission. `action-hosting-deploy@v0` is a rolling tag and updates from the maintainer; the github-actions Dependabot group will also surface action bumps going forward.

## Safety
YAML validated (all 4 parse). Bare `checkout` usage, so v5 is drop-in. No commit-hook or deploy-logic changes.