### PR TITLE
fix(readout): polish unit-description readout and map-card citation

### DIFF
--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2085,6 +2085,14 @@ function scaleLayerId(scaleNum) {
     return null;
 }
 
+// series_id as shown to the user. A few legacy ids read better relabeled; the underlying
+// series_id is still used everywhere it matters (DOI link, getData, share links).
+function displaySeriesId(id) {
+    if (!id) return '';
+    if (id === 'Q-2thru5') return 'Q2-Q5';
+    return id;
+}
+
 // the functional layer-toggle for a footprint, or null if its category has no working
 // layer (geomaps_irreg / geomaps_1x2 -- these never gate the readout via a checkbox)
 function footprintToggle(attrs) {
@@ -2111,7 +2119,11 @@ function buildAccordion(ftrs, openIdx) {
         var badge = (a.units === 'True' && sc < 500)   // full descriptions, more detailed than 500k
             ? '<span class="desc-badge-wrap" title="Full unit descriptions available">' + HAMMER + '</span>' : '';
         var yr = parseInt(a.pub_year);
-        var title = badge + scaleLabel(sc) + '&nbsp;&middot;&nbsp;' + nm + (yr ? '<span class="readout-year">&nbsp;&middot;&nbsp;' + yr + '</span>' : '');
+        var sid = displaySeriesId(a.series_id);
+        // scale . map name . series id . year -- all in the same title style
+        var title = badge + scaleLabel(sc) + '&nbsp;&middot;&nbsp;' + nm
+            + (sid ? '&nbsp;&middot;&nbsp;' + sid : '')
+            + (yr ? '&nbsp;&middot;&nbsp;' + yr : '');
         var offCls = (lyrId && !on) ? ' layer-off' : '';
         var toggle = lyrId
             ? '<label class="layer-switch" title="Show this map layer on the map">' +
@@ -2204,6 +2216,7 @@ function fetchAttributes(ftrset, evt) {
 
     byId('udTab').innerHTML = buildAccordion(accordionFtrs, openIdx);
     byId("viewDiv").style.cursor = "auto";
+    prefetchPubData(accordionFtrs);   // warm pub records so section links appear on open
     loadSection(openIdx);
     addFmMarker(evt.mapPoint.longitude.toFixed(5), evt.mapPoint.latitude.toFixed(5));
 }
@@ -2289,7 +2302,7 @@ function loadUnitDescription(atts, evt, bodyEl) {
         bodyEl.innerHTML =
             '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
             '<div class="unit-desc-text">' + desc + '</div>' +
-            '<div class="unit-desc-ref">&bull;DOI: <a target="_blank" href="https://doi.org/10.34191/' + atts.series_id + '">https://doi.org/10.34191/' + atts.series_id + '</a></div>';
+            '<div class="unit-desc-ref">&bull;<a target="_blank" href="https://doi.org/10.34191/' + atts.series_id + '">DOI Link</a></div>';
     }).catch(function (err) {
         if (bodyEl.isConnected) bodyEl.innerHTML = '<div class="unit-desc-text">Could not load the unit description.</div>';
         console.error('unit description fetch failed for ' + atts.series_id + ':', err);
@@ -2297,15 +2310,31 @@ function loadUnitDescription(atts, evt, bodyEl) {
 }
 
 // fetch a map's publication record (PDF url, geotiff path, publisher) with no render
-// side effects (unlike getData, which repaints the downloads panel via printPubs)
+// side effects (unlike getData, which repaints the downloads panel via printPubs). The
+// promise is memoized by series_id so a prefetched record is reused instantly on open;
+// a failed fetch is dropped from the cache so it can be retried on the next click.
+var pubDataCache = {};
 function getPubData(seriesId) {
+    if (pubDataCache[seriesId]) return pubDataCache[seriesId];
     var url = projectName + '/getData?mapid=' + encodeURIComponent(seriesId);
-    return fetch(url)
+    var p = fetch(url)
         .then(function (r) { if (!r.ok) throw new Error('getData ' + r.status); return r.json(); })
         .then(function (data) {
             var rec = (data && data[0]) ? data[0] : null;
             return rec ? { pub_url: rec.pub_url, geotiff: rec.geotiff, pub_publisher: rec.pub_publisher } : null;
         });
+    p.catch(function () { delete pubDataCache[seriesId]; });
+    pubDataCache[seriesId] = p;
+    return p;
+}
+
+// warm the cache for the publication-only footprints at the click point, in parallel, so
+// their links are already loaded by the time the user opens that section (item: faster links)
+function prefetchPubData(ftrs) {
+    for (var i = 0; i < ftrs.length; i++) {
+        var a = ftrs[i].attributes;
+        if (a.units !== 'True' && a.series_id) getPubData(a.series_id).catch(function () {});
+    }
 }
 
 // load a units=False map's publication links into the given section body
@@ -2314,11 +2343,20 @@ function loadPublicationOnly(atts, bodyEl) {
     function paint(rec) {
         if (!bodyEl.isConnected) return;
         var links = [];
-        var pub = (rec && rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
-        var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
-        if (isUgs) links.push('<a target="_blank" href="https://doi.org/10.34191/' + sid + '">Publication page</a>');
-        if (rec && rec.pub_url) links.push('<a target="_blank" href="' + rec.pub_url + '">PDF</a>');
-        if (rec && rec.geotiff) links.push('<a target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
+        // the publisher decides both the label and the URL, so only emit the catalog link
+        // once we have the record (rec is null on the first, pre-fetch paint).
+        if (rec) {
+            var pub = (rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
+            var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
+            // UGS/UGMS: link our DOI (we are the registrant). Maps published by others
+            // (e.g. USGS): we host a catalog page but not their DOI, so link the UGS
+            // publication page and don't call it a DOI link.
+            links.push(isUgs
+                ? '<a target="_blank" href="https://doi.org/10.34191/' + sid + '">DOI Link</a>'
+                : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + sid + '">Publication Page</a>');
+            if (rec.pub_url) links.push('<a target="_blank" href="' + rec.pub_url + '">PDF</a>');
+            if (rec.geotiff) links.push('<a target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
+        }
         var linkHtml = links.length ? ('<div class="unit-desc-ref">' + links.join('&nbsp;&middot;&nbsp;') + '</div>') : '';
         bodyEl.innerHTML = '<div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div>' + linkHtml;
     }
@@ -2534,7 +2572,15 @@ var printPubs = function(pubResults){
         $( titleArea ).append( '<p class="mapInfo">'+ info +'</p>' );
         $( titleArea ).append( '<p class="mapScale">'+ scaleInt +'k</p>' );
         var publisher = (arr.pub_publisher) ? arr.pub_publisher : "";
-        var reftxt = arr.pub_author +', '+ arr.pub_year +', '+ arr.pub_name +'. '+ arr.series_id +'. '+ publisher +'. 1:'+ scaleInt +',000 scale.';
+        // pub_sec_author is free text that may already include "and" + multiple names
+        // (e.g. "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't
+        // already have one -- avoids "Stokes, and Hintze, and Madsen".
+        var authors = arr.pub_author;
+        if (arr.pub_sec_author) {
+            var sec = String(arr.pub_sec_author).trim();
+            if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
+        }
+        var reftxt = authors +', '+ arr.pub_year +', '+ arr.pub_name +'. '+ arr.series_id +'. '+ publisher +'. 1:'+ scaleInt +',000 scale.';
         var copydiv = $('<p class="mapRef smallscroll tooltip ref-right" data-title="click to copy map reference"><span id="copyRef" data-title="copy reference" title="copy reference to clip board" class="esri-icon-duplicate"></span>&nbsp;'+ reftxt +'</p><br><br>');
         copydiv.click(function(n) {
             //console.log('copy to clipboard');

--- a/public/style.css
+++ b/public/style.css
@@ -1472,7 +1472,7 @@ p:last-child {
 }
 
 .unit-desc-title {
-    font-size: 15px;
+    font-size: 13px;
     font-weight: 600;
 }
 .unit-age {
@@ -2134,28 +2134,28 @@ p:last-child {
 } /*  end @media for mobile */
 
 /* unit-readout: the clicked map pinned at top as the answer + the other maps as a single-open
-   accordion in a scrollable section below. Height-bounded so the primary description and the
-   other-maps section each scroll within their own box and nothing gets pushed off screen. */
-.map-readout { display: flex; flex-direction: column; max-height: 72vh; font-size: 13px; }
+   accordion below. The readout flows naturally and #unitsPane is the single scroll container,
+   so content (e.g. the last section's link/toggle) can never be pushed off screen -- including
+   at high browser zoom, where the old competing vh/% height caps used to clip it. */
+.map-readout { font-size: 13px; }
 
-/* primary = the clicked map, pinned at the top; its description scrolls within a capped box */
-.readout-primary { flex: 0 1 auto; min-height: 0; display: flex; flex-direction: column; padding: 0 2px; }
-.readout-primary-head { flex: none; padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
-.readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; }
-.readout-primary .map-section-readout { flex: 1 1 auto; min-height: 0; max-height: 45vh; overflow-y: auto; overscroll-behavior: contain; }
+/* primary = the clicked map, pinned at the top */
+.readout-primary { padding: 0 2px; }
+.readout-primary-head { padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+.readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
 
-/* the other maps, in their own scrollable section below the primary */
-.readout-others { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; overscroll-behavior: contain; border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
-.other-maps-label { flex: none; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
+/* the other maps, listed below the primary */
+.readout-others { border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
+.other-maps-label { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
 
 /* other-map cards (collapsed headers, single-open) */
-.map-section { flex: none; border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
+.map-section { border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
 .map-section:hover { background: #eceff4; }
 .map-section.open { background: #fff; border-color: #d4dde7; box-shadow: 0 1px 5px rgba(50,106,152,.12); }
 .map-section-header { display: flex; align-items: center; gap: 8px; padding: 7px 9px; cursor: pointer; }
 .map-section-header:focus { outline: 2px solid #6396fc; outline-offset: -2px; }
 .map-section-header:focus:not(:focus-visible) { outline: none; }
-.map-section-title { flex: 1; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 14px; letter-spacing: .3px; line-height: 1.15; color: #4a4a4a; }
+.map-section-title { flex: 1; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 14px; letter-spacing: .3px; line-height: 1.15; color: #4a4a4a; overflow-wrap: anywhere; }
 .map-section.open .map-section-title { color: #326A98; }
 
 /* pure-css chevron */
@@ -2164,7 +2164,6 @@ p:last-child {
 
 .map-section-body { display: none; padding: 0 10px 9px; }
 .map-section.open .map-section-body { display: block; }
-.map-section.open .map-section-readout { max-height: 30vh; overflow-y: auto; overscroll-behavior: contain; }
 
 /* layer toggle switch (on = accent blue), behaves like a layer-list checkbox */
 .layer-switch { display: inline-flex; align-items: center; gap: 7px; margin-top: 9px; cursor: pointer; font-size: 11px; color: #6a6a6a; user-select: none; }
@@ -2178,7 +2177,6 @@ p:last-child {
 /* rock-hammer badge: full unit descriptions available for this map */
 .desc-badge-wrap { display: inline-flex; vertical-align: middle; margin-right: 4px; position: relative; top: -1px; }
 .desc-badge { fill: #326A98; }
-.readout-year { color: #9a9a9a; font-weight: normal; }
 
 /* gray a map's title when its layer is off (mirrors the layer list) */
 .readout-primary.layer-off .readout-primary-title { color: #a6a6a6; }

--- a/public/style.css
+++ b/public/style.css
@@ -1081,9 +1081,11 @@ see https://www.w3schools.com/howto/howto_css_four_columns.asp */
     width: 220px;
     display: block;
     float:left;
-    /*must have for scroll to work */
-    height: 100%; 
-    overflow-y: scroll;
+    /* bound to the space below the header bar instead of height:100% (which equals the
+       whole slide height and, starting below the header, spilled the citation past the
+       fixed 245px card and off the bottom of the screen). Scroll any remaining overflow. */
+    max-height: 160px;
+    overflow-y: auto;
     overflow-x: hidden;
 }
 
@@ -1125,13 +1127,13 @@ see https://www.w3schools.com/howto/howto_css_four_columns.asp */
 
 .mapScale {
     font-family: Eagle;
-    font-size: 68pt;
+    font-size: 44pt;
     letter-spacing: -4px;
     opacity: .3;
     width: 250px;
-    padding-top: 20px;
-    padding-bottom: 8px;
-    line-height: 30pt;
+    padding-top: 8px;
+    padding-bottom: 4px;
+    line-height: 24pt;
 }
 .mapRef {
     font-family: 'Corbel Regular';
@@ -1460,7 +1462,7 @@ p:last-child {
     position: absolute;
     bottom: 0px;
     right: -5px;
-    max-height:75%;
+    max-height:75vh;
     width: 300px;
     z-index: 99;
     border-radius: 6px;
@@ -1472,7 +1474,7 @@ p:last-child {
 }
 
 .unit-desc-title {
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 600;
 }
 .unit-age {
@@ -2134,22 +2136,25 @@ p:last-child {
 } /*  end @media for mobile */
 
 /* unit-readout: the clicked map pinned at top as the answer + the other maps as a single-open
-   accordion below. The readout flows naturally and #unitsPane is the single scroll container,
-   so content (e.g. the last section's link/toggle) can never be pushed off screen -- including
-   at high browser zoom, where the old competing vh/% height caps used to clip it. */
-.map-readout { font-size: 13px; }
+   accordion below. .map-readout is height-bounded so the primary description scrolls in its own
+   box and the "other maps" section stays pinned at the bottom. Its cap is kept strictly inside
+   #unitsPane (max-height:75vh) minus that pane's 16px padding (plus a buffer), so #unitsPane
+   itself never has to scroll the accordion and the bottom section can't be clipped -- including
+   at high browser zoom, where the fixed padding used to overrun the old, too-close 72vh/75%. */
+.map-readout { display: flex; flex-direction: column; max-height: calc(75vh - 30px); font-size: 13px; }
 
-/* primary = the clicked map, pinned at the top */
-.readout-primary { padding: 0 2px; }
-.readout-primary-head { padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+/* primary = the clicked map, pinned at the top; its description scrolls within a capped box */
+.readout-primary { flex: 0 1 auto; min-height: 0; display: flex; flex-direction: column; padding: 0 2px; }
+.readout-primary-head { flex: none; padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
 .readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
+.readout-primary .map-section-readout { flex: 1 1 auto; min-height: 0; max-height: 45vh; overflow-y: auto; overscroll-behavior: contain; }
 
-/* the other maps, listed below the primary */
-.readout-others { border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
-.other-maps-label { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
+/* the other maps, pinned in their own scrollable section below the primary */
+.readout-others { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; overscroll-behavior: contain; border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
+.other-maps-label { flex: none; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
 
 /* other-map cards (collapsed headers, single-open) */
-.map-section { border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
+.map-section { flex: none; border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
 .map-section:hover { background: #eceff4; }
 .map-section.open { background: #fff; border-color: #d4dde7; box-shadow: 0 1px 5px rgba(50,106,152,.12); }
 .map-section-header { display: flex; align-items: center; gap: 8px; padding: 7px 9px; cursor: pointer; }
@@ -2164,6 +2169,7 @@ p:last-child {
 
 .map-section-body { display: none; padding: 0 10px 9px; }
 .map-section.open .map-section-body { display: block; }
+.map-section.open .map-section-readout { max-height: 30vh; overflow-y: auto; overscroll-behavior: contain; }
 
 /* layer toggle switch (on = accent blue), behaves like a layer-list checkbox */
 .layer-switch { display: inline-flex; align-items: center; gap: 7px; margin-top: 9px; cursor: pointer; font-size: 11px; color: #6a6a6a; user-select: none; }


### PR DESCRIPTION
## Summary
Polish pass on the unit-description readout shipped in #126, plus a stopgap fix to the Map Downloads card. Targets `dev`.

## Changes
**Publication links (readout sections)**
- UGS/UGMS maps link **DOI Link** → `doi.org/10.34191/<series_id>`; other publishers (e.g. USGS) link **Publication Page** → `geology.utah.gov/publication-details/?pub=<series_id>` (we host the catalog page, not their DOI). Non-UGS maps previously showed no link at all.

**Section titles**
- Show the series_id: `scale · name · series_id · year`, all in one uniform style (dropped the differently-styled year span). The legacy id `Q-2thru5` displays as `Q2-Q5` (display-only — URLs still use the real id). Long unbroken ids wrap.

**Performance**
- Memoize `getData` lookups and prefetch them on click so a section's links are ready when it opens.

**Citation (Map Downloads)**
- Include `pub_sec_author` when present, with a smart "and" join (the field is free text that may already contain "and").

**Layout / sizing**
- Unit title (`.unit-desc-title`) 15px → 12px so it reads below the accordion header.
- Fixed the readout being clipped at high browser zoom: the pane's fixed 16px padding overran the old, too-close 72vh/75% caps. `.map-readout` now caps at `calc(75vh - 30px)` strictly inside `#unitsPane` (75vh), keeping the "other maps" section pinned while preventing clipping at any zoom.
- Map Downloads card: `.titleArea` no longer uses `height:100%` (which spilled the citation past the fixed 245px card and off the bottom of the screen); it's bounded and scrolls, and the oversized 68pt scale watermark is trimmed to 44pt so the citation is visible. Stopgap — this card is slated for consolidation into the readout.

## Verification
- `node --check` passes. Live `getData`/DOI checks confirm publisher routing (UGMS → DOI, USGS → Publication Page) and the secondary-author format.
- Reviewed by a code-review agent (correctness) and a frontend pass (zoom/layout), plus a focused re-review of the publisher routing — no high/medium findings.
- Verified locally in the browser.

## Notes
- `faf69e8` introduced a single-scroll panel that `c0063c5` refined back to the pinned layout — consider **squash-merge** for tidy history.
- Follow-up: consolidate Map Downloads (downloads + citation) into the readout and simplify the panel's scrolling.