### PR TITLE
feat(readout): consolidate downloads, citation, and tools into the click readout

### DIFF
--- a/docs/plans/2026-06-06-consolidated-readout-panel.md
+++ b/docs/plans/2026-06-06-consolidated-readout-panel.md
@@ -1,0 +1,447 @@
+# Consolidated Feature Readout Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold the Map Downloads card's downloads, citation, and per-map actions into the click readout, with a responsive two-column (desktop) / stacked-with-disclosure (mobile) layout and a single scroll container — vanilla, no new libraries.
+
+**Architecture:** All changes live in `public/mapcontrols.js` + `public/style.css` (the repo's single-file pattern). Add shared helpers (`buildCitation`, `buildPubLink`), a `renderResources()` block injected into each readout section, event-delegated tool handlers, responsive CSS at a 768px breakpoint, and a single-scroll panel with a pinned header (achieved by making `#udTab` the scroller and switching `#unitsPane` show/hide to class-based so a CSS flex layout holds).
+
+**Tech Stack:** Vanilla JS (ArcGIS Maps SDK + jQuery) + CSS; Firebase `getData` + pg_featureserv. No build step.
+
+**Testing note:** This repo has no frontend test runner (`npm test` is a no-op). The readout panel is fully testable on `http://localhost:5000` via `npx firebase serve --only hosting` — the footprints layer (AGOL), pg_featureserv, and `getData` are all public, so clicking the map and exercising the panel works locally. Only the *secured ArcGIS base geology tiles* won't render locally; that does not block testing the panel's content/layout. After every code change run `node --check public/mapcontrols.js`; after CSS changes confirm braces balance (`[ "$(tr -cd '{' < public/style.css | wc -c)" = "$(tr -cd '}' < public/style.css | wc -c)" ]`). Full base-tile fidelity is verified on the dev site after merge.
+
+Spec: `docs/specs/2026-06-06-consolidated-readout-panel-design.md`.
+
+---
+
+## File structure
+
+- **Modify** `public/mapcontrols.js` — `buildCitation`/`buildPubLink` helpers; `renderResources`/`fillResources`; restructure `loadUnitDescription` + `loadPublicationOnly` section bodies; delegated tool/copy/xsection/disclosure handlers; widen `prefetchPubData`; class-based `#unitsPane` show/hide.
+- **Modify** `public/style.css` — responsive section grid, resources rail, disclosure groups, download/tool/citation styling (reusing the existing `pdfIcon`/`gisIcon`/`tiffIcon`/`xsecIcon`/`purIcon` glyphs), mobile description truncation, single-scroll panel sizing + bottom sheet, pinned-header flex layout.
+
+No new files (single-file pattern). No `package.json` changes (no new dependency).
+
+Out of scope (separate follow-ups): removing the Map Downloads mode/swiper (`#identifyPanel`, `toggleMapDl`, `#mapsPane`, `printPubs`); the layer-list / scale-button reorg.
+
+---
+
+### Task 1: Shared helpers — `buildCitation` + `buildPubLink`
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add the two helpers** immediately after the `displaySeriesId` function.
+
+```js
+// citation string for a publication record (shared by the readout + the downloads carousel).
+// pub_sec_author is free text that may already contain "and" + multiple names (e.g.
+// "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't already have one.
+function buildCitation(rec) {
+    if (!rec) return '';
+    var authors = rec.pub_author || '';
+    if (rec.pub_sec_author) {
+        var sec = String(rec.pub_sec_author).trim();
+        if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
+    }
+    var scaleInt = scaleToInt(rec.pub_scale);
+    var publisher = rec.pub_publisher ? rec.pub_publisher : '';
+    return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + '. 1:' + scaleInt + ',000 scale.';
+}
+
+// publisher-aware publication link: UGS/UGMS -> our DOI; other publishers -> the UGS catalog
+// page (we host the page but not their DOI, so it must not be labeled a DOI link).
+function buildPubLink(seriesId, rec) {
+    var pub = (rec && rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
+    var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
+    return isUgs
+        ? '<a target="_blank" href="https://doi.org/10.34191/' + seriesId + '">DOI Link</a>'
+        : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + seriesId + '">Publication Page</a>';
+}
+```
+
+- [ ] **Step 2: Use `buildCitation` in `printPubs`.** Find the citation block in `printPubs` (the `var authors = arr.pub_author; if (arr.pub_sec_author) {…} var reftxt = authors + ', ' + arr.pub_year + …;`) and replace the whole `authors`/`reftxt` computation with:
+
+```js
+        var reftxt = buildCitation(arr);
+```
+
+(`publisher`/`scaleInt` locals above it stay; only the author-join + `reftxt` lines collapse into the helper call.)
+
+- [ ] **Step 3: Syntax check.** Run: `node --check public/mapcontrols.js` — expect no output (exit 0).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "refactor(readout): extract buildCitation + buildPubLink helpers"
+```
+
+---
+
+### Task 2: getData returns the full record + prefetch all footprints
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Return the full publication record from `getPubData`.** Today it strips the result to `{ pub_url, geotiff, pub_publisher }`, but the resources block needs `gis_data`, `x_section`, `bsurl`, and the citation fields. In `getPubData`, replace the `.then(function (data) { var rec = …; return rec ? { pub_url:…, geotiff:…, pub_publisher:… } : null; })` with:
+
+```js
+        .then(function (data) { return (data && data[0]) ? data[0] : null; });
+```
+
+(The full record is a superset of the old shape, so the existing `pub_url`/`geotiff`/`pub_publisher` reads still work. `getPubData` remains memoized by `series_id`.)
+
+- [ ] **Step 2: Widen `prefetchPubData`.** Replace the function body (currently filters `a.units !== 'True'`) with:
+
+```js
+function prefetchPubData(ftrs) {
+    for (var i = 0; i < ftrs.length; i++) {
+        var sid = ftrs[i].attributes.series_id;
+        if (sid) getPubData(sid).catch(function () {});
+    }
+}
+```
+
+(Every section now shows downloads/citation, so warm the cache for all maps at the point.)
+
+- [ ] **Step 3: Syntax check.** Run: `node --check public/mapcontrols.js` — exit 0.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "perf(readout): return full pub record + prefetch all footprints at the point"
+```
+
+---
+
+### Task 3: Resources renderer + wire into both section paths
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add `renderResources` + `fillResources`** immediately after `buildPubLink`.
+
+```js
+// the resources block (publication link, downloads, citation, map tools) for one section.
+// rec is the getData record (may be null while loading / if the map has no record).
+function renderResources(rec, atts) {
+    var sid = atts.series_id;
+    var pubLink = '<div class="res-publink">' + buildPubLink(sid, rec) + '</div>';
+
+    var dl = [];
+    if (rec && rec.pub_url)   dl.push('<a class="downloadList pdfIcon"  target="_blank" href="' + rec.pub_url + '">PDF</a>');
+    if (rec && rec.gis_data)  dl.push('<a class="downloadList gisIcon"  target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.gis_data + '">GIS data</a>');
+    if (rec && rec.geotiff)   dl.push('<a class="downloadList tiffIcon" target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
+    if (rec && rec.x_section) dl.push('<a class="downloadList xsecIcon res-xsec" href="#" data-xsec="' + rec.x_section + '">Cross-section</a>');
+    if (rec && rec.bsurl)     dl.push('<a class="downloadList purIcon" target="_blank" href="https://utahmapstore.com/products/' + sid + '">Purchase</a>');
+    var downloads = dl.length
+        ? '<div class="res-downloads">' + dl.join('') + '</div>'
+        : '<div class="res-empty">No downloads available for this map.</div>';
+
+    var citeText = rec ? buildCitation(rec) : '';
+    var cite = citeText
+        ? '<div class="res-cite"><span class="res-cite-text">' + citeText + '</span>' +
+          '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
+        : '';
+
+    var tools = '<div class="res-tools">' +
+        '<button type="button" class="res-tool res-pan"   title="Pan to this map">Pan to</button>' +
+        '<button type="button" class="res-tool res-zoom"  title="Zoom to this map">Zoom to</button>' +
+        '<button type="button" class="res-tool res-share" title="Copy a shareable link">Copy link</button>' +
+        '</div>';
+
+    var dlOpen = (atts.units === 'True') ? '' : ' open';   // pub-only maps lead with downloads
+    return pubLink +
+        '<div class="readout-group readout-group-dl' + dlOpen + '">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="' + (dlOpen ? 'true' : 'false') + '">Downloads &amp; citation</button>' +
+            '<div class="readout-group-content">' + downloads + cite + '</div>' +
+        '</div>' +
+        '<div class="readout-group readout-group-tools">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="false">Map tools</button>' +
+            '<div class="readout-group-content">' + tools + '</div>' +
+        '</div>';
+}
+
+// fill a section's .readout-resources once the (prefetched) getData record resolves
+function fillResources(atts, container) {
+    if (!container) return;
+    getPubData(atts.series_id)
+        .then(function (rec) { if (container.isConnected) container.innerHTML = renderResources(rec, atts); })
+        .catch(function () { if (container.isConnected) container.innerHTML = renderResources(null, atts); });
+}
+```
+
+- [ ] **Step 2: Restructure the `units==='True'` render in `loadUnitDescription`.** Replace the `bodyEl.innerHTML = …` assignment (identity + description + the old `.unit-desc-ref` DOI line) with the section-body wrapper + a resources placeholder, then call `fillResources`:
+
+```js
+        bodyEl.innerHTML =
+            '<div class="readout-section-body">' +
+                '<div class="readout-main">' +
+                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
+                    '<div class="unit-desc-text">' + desc + '</div>' +
+                    '<button type="button" class="readout-show-more">Show more</button>' +
+                '</div>' +
+                '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+            '</div>';
+        fillResources(atts, bodyEl.querySelector('.readout-resources'));
+```
+
+(The old `<div class="unit-desc-ref">…DOI Link…</div>` line is removed — the publication link now lives in the resources block.)
+
+- [ ] **Step 3: Replace `loadPublicationOnly` entirely** with the unified version (its old `paint`/`getPubData` body is superseded by `fillResources`/`renderResources`):
+
+```js
+// load a units=False map's publication-only section (no unit description)
+function loadPublicationOnly(atts, bodyEl) {
+    bodyEl.innerHTML =
+        '<div class="readout-section-body readout-pubonly">' +
+            '<div class="readout-main"><div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div></div>' +
+            '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+        '</div>';
+    fillResources(atts, bodyEl.querySelector('.readout-resources'));
+}
+```
+
+- [ ] **Step 4: Syntax check.** Run: `node --check public/mapcontrols.js` — exit 0.
+
+- [ ] **Step 5: Manual check.** Run `npx firebase serve --only hosting`; in the browser, enable the unit-descriptions pane and click a detailed map (e.g. Duchesne `M-300DM`) and the Utah State 250k (`Q-2thru5`). Expected: each open section shows the publication link plus "Downloads & citation" and "Map tools" groups (unstyled until Task 5); `Q-2thru5` shows PDF/GeoTIFF + the multi-author citation; a USGS quad (`I-2462`) shows "Publication Page".
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "feat(readout): render downloads, citation, and map tools in each section"
+```
+
+---
+
+### Task 4: Section tool handlers (pan/zoom/share, copy, cross-section)
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add delegated handlers** next to the other `$(document).on(...)` / jQuery click handlers (sections are rebuilt on every click, so delegation is required).
+
+```js
+// resources: copy citation
+$(document).on('click', '#udTab .res-copy', function (e) {
+    e.preventDefault();
+    copyToClipboard(decodeURIComponent(this.getAttribute('data-cite') || ''));
+});
+// resources: open the cross-section in the existing image viewer
+$(document).on('click', '#udTab .res-xsec', function (e) {
+    e.preventDefault();
+    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('#xsection-pane').removeClass('hidden');
+});
+// resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx
+$(document).on('click', '#udTab .res-tool', function (e) {
+    e.preventDefault();
+    var host = this.closest('[data-idx]');
+    if (!host) return;
+    var ftr = accordionFtrs[parseInt(host.getAttribute('data-idx'), 10)];
+    if (!ftr || !ftr.geometry) return;
+    var ext = ftr.geometry.extent;
+    if (this.classList.contains('res-pan') && ext) {
+        view.center = ext.center;
+    } else if (this.classList.contains('res-zoom') && ext) {
+        view.extent = ext;
+        view.zoom = view.zoom - 1;
+    } else if (this.classList.contains('res-share')) {
+        var sid = ftr.attributes.series_id;
+        var sc = parseInt(ftr.attributes.scale);
+        var lyrs = (sc <= 24) ? '24k' : (sc < 250) ? '100k' : '500k';
+        var base = window.location.href.split('#')[0].split('?')[0];
+        copyToClipboard(encodeURI(base + '?view=scene&sid=' + sid + '&layers=' + lyrs));
+    }
+});
+```
+
+- [ ] **Step 2: Syntax check.** Run: `node --check public/mapcontrols.js` — exit 0.
+
+- [ ] **Step 3: Manual check.** Reload local; open a section. Expected: "Copy link" / "Pan to" / "Zoom to" act on that map's footprint; the citation copy button copies the reference; "Cross-section" (on a map that has one) opens the `#xsection-pane` image.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "feat(readout): wire section pan/zoom/share, citation copy, and cross-section viewer"
+```
+
+---
+
+### Task 5: Responsive layout, disclosure groups, icon reuse, mobile truncation
+
+**Files:** Modify `public/style.css`, `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add the resources/section CSS** (append within the readout CSS region of `public/style.css`).
+
+```css
+/* consolidated section: stacked by default; two columns on desktop (Task assigns the media query) */
+.readout-section-body { display: block; }
+.readout-main, .readout-resources { min-width: 0; }
+
+.res-publink { font-size: 11px; margin: 4px 0; }
+.res-downloads { display: flex; flex-direction: column; gap: 3px; margin: 4px 0; }
+.res-downloads .downloadList { font-size: 12px; line-height: 18px; }
+.res-empty { font-size: 11px; color: #9a9a9a; margin: 4px 0; }
+
+.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 10px; line-height: 13px; color: #555; }
+.res-cite-text { flex: 1; }
+.res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
+
+.res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.res-tool { font-size: 11px; padding: 3px 8px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
+.res-tool:hover { background: #eceff4; }
+
+/* disclosure groups: collapsible on mobile, always-open rail on desktop */
+.readout-group { margin-top: 8px; }
+.readout-group-toggle { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; border: none; background: none; padding: 4px 0; cursor: pointer; font: 600 12px "Avenir Next W00", Helvetica, Arial, sans-serif; color: #4a4a4a; }
+.readout-group-toggle::before { content: "\25B8"; font-size: 9px; transition: transform .15s ease; }
+.readout-group.open .readout-group-toggle::before { transform: rotate(90deg); }
+.readout-group-content { display: none; padding-left: 2px; }
+.readout-group.open .readout-group-content { display: block; }
+
+.readout-show-more { display: none; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
+
+@media (min-width: 768px) {
+    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(165px, 1fr); gap: 12px; }
+    .readout-pubonly .readout-section-body { grid-template-columns: 1fr; }
+    .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
+    .readout-group-content { display: block; }
+    .readout-group { margin-top: 10px; }
+}
+
+@media (max-width: 767px) {
+    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
+    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
+    .readout-show-more { display: inline-block; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .readout-group-toggle::before { transition: none; }
+}
+```
+
+- [ ] **Step 2: Add the disclosure + show-more handlers** in `public/mapcontrols.js` (next to the Task 4 handlers).
+
+```js
+// resources: toggle a disclosure group (mobile); description show more/less (mobile)
+$(document).on('click', '#udTab .readout-group-toggle', function () {
+    var open = this.parentNode.classList.toggle('open');
+    this.setAttribute('aria-expanded', open ? 'true' : 'false');
+});
+$(document).on('click', '#udTab .readout-show-more', function () {
+    var main = this.closest('.readout-main');
+    if (!main) return;
+    this.textContent = main.classList.toggle('expanded') ? 'Show less' : 'Show more';
+});
+```
+
+- [ ] **Step 3: Checks.** Run `node --check public/mapcontrols.js` (exit 0) and confirm `style.css` braces balance.
+
+- [ ] **Step 4: Manual check.** Local browser. Desktop window (>768px): open section shows description left, resources rail right (groups expanded, no toggles). Narrow the window (<768px): layout stacks, groups collapse with ▸ toggles, description clamps to 5 lines with "Show more".
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/style.css public/mapcontrols.js
+git commit -m "feat(readout): responsive 2-col/stacked layout, disclosure groups, mobile truncation"
+```
+
+---
+
+### Task 6: Single-scroll panel + widen desktop / bottom sheet mobile
+
+**Files:** Modify `public/style.css`.
+
+- [ ] **Step 1: Revert the pinned-flex readout rules to plain flow** so there is one scroll container. In `public/style.css`, change:
+
+```css
+.map-readout { display: flex; flex-direction: column; max-height: calc(75vh - 30px); font-size: 13px; }
+```
+to:
+```css
+.map-readout { font-size: 13px; }
+```
+Change `.readout-primary { flex: 0 1 auto; min-height: 0; display: flex; flex-direction: column; padding: 0 2px; }` to `.readout-primary { padding: 0 2px; }`. Change `.readout-others { … }` to drop `flex`, `min-height`, `display:flex`, `overflow-y`, `overscroll-behavior` (keep its `border-top`/`margin-top`/`padding-top`). **Delete** the rules `.readout-primary .map-section-readout { … max-height: 45vh … }` and `.map-section.open .map-section-readout { max-height: 30vh … }`. Drop `flex: none;` from `.map-section` and `.other-maps-label`.
+
+(Progressive disclosure now keeps sections compact, so a single panel scrollbar is correct and the nested `vh` caps that caused the multi-scrollbar confusion are gone.)
+
+- [ ] **Step 2: Widen the desktop panel + add the mobile bottom sheet.** Change `#unitsPane`'s `width: 300px;` to `width: 440px;` and its `opacity: 0.85;` to `opacity: 0.96;` (leave `max-height`, `position`, `bottom`, `right`, `padding` as set in PR #144). Add, after the `#unitsPane` rule:
+
+```css
+@media (max-width: 767px) {
+    #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }
+}
+```
+
+- [ ] **Step 3: Confirm braces balance** in `style.css`.
+
+- [ ] **Step 4: Manual check.** Local browser. Desktop: panel is ~440px, one scrollbar, text crisp. Zoom Chrome to ~150–175% with a long description + an open "other map": nothing clipped, single scrollbar. Narrow window: panel spans full width, bottom-anchored.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/style.css
+git commit -m "feat(readout): single-scroll panel, 440px desktop / full-width bottom sheet on mobile"
+```
+
+---
+
+### Task 7: Pin the panel header/close (flex panel + class-based show/hide)
+
+**Files:** Modify `public/style.css`, `public/mapcontrols.js`.
+
+- [ ] **Step 1: Make `#udTab` the scroll container and `#unitsPane` a non-scrolling flex column.** In `public/style.css`, change `#unitsPane`'s `overflow-y: auto;` to `overflow: hidden;` and add `display: flex; flex-direction: column;`. Add these rules after it:
+
+```css
+/* #udTab is the single scroller; the close button (absolute in #unitsPane) stays pinned */
+#udTab { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+#unitsPane.hidden { display: none; }   /* beat the id-specificity of display:flex when hidden */
+```
+
+- [ ] **Step 2: Switch `#unitsPane` show/hide to class-based** so jQuery's `.show()` can't inject `display:block` over the flex layout. In `public/mapcontrols.js` replace every `$("#unitsPane").show()` with `$("#unitsPane").removeClass("hidden")` (the click handler that opens the readout, and the Macrostrat/out-of-state paths — there are three) and every `$("#unitsPane").hide()` with `$("#unitsPane").addClass("hidden")` (the `#fms-close` handler and `toggleMapDl`). Leave existing `addClass("hidden")` calls as-is.
+
+- [ ] **Step 3: Syntax check.** Run: `node --check public/mapcontrols.js` (exit 0); confirm `style.css` braces balance.
+
+- [ ] **Step 4: Manual check.** Local browser. Open the readout, scroll a long section: the close "✕" stays pinned (does not scroll away). Confirm the panel still opens on click and closes via ✕, and that switching to/from any other tool still hides/shows it.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/style.css public/mapcontrols.js
+git commit -m "feat(readout): pin panel header/close via flex layout + class-based show/hide"
+```
+
+---
+
+### Task 8: Verification matrix + pre-commit review
+
+**Files:** none unless fixes are needed.
+
+- [ ] **Step 1: Run the full matrix** locally (`npx firebase serve`):
+  - Desktop ≥768px: two-column section, full description, rail with publication link + downloads (icons) + citation (copy works) + tools (pan/zoom/share); single scrollbar; pinned ✕.
+  - Mobile <768px: bottom sheet, one column, description clamps with "Show more", groups collapse/expand.
+  - `units==='True'` (`M-300DM`): description + **DOI Link** + downloads.
+  - `units!=='True'` UGS/UGMS (`Q-2thru5`): publication note + **DOI Link** + PDF/GeoTIFF + multi-author citation.
+  - non-UGS (`I-2462`, USGS): **Publication Page** (not DOI) + any downloads.
+  - Multiple maps at a point: accordion of others; opening one renders the same responsive body; clicked map stays default-open.
+  - Cross-section viewer opens; "Copy link" yields `…?view=scene&sid=…&layers=…`.
+
+- [ ] **Step 2: Final checks.** `node --check public/mapcontrols.js` (exit 0); `style.css` braces balance.
+
+- [ ] **Step 3: Pre-commit review.** Per repo convention, run a code-review subagent and a frontend reviewer on the cumulative diff (`git diff origin/dev...HEAD`): correctness (the two render paths don't regress the 500k / Macrostrat / out-of-state cases; delegation handlers; class-based show/hide doesn't break any visibility check), and layout (single-scroll, responsive grid, sticky close, zoom). Address every finding in the same pass.
+
+- [ ] **Step 4: Commit any review fixes**, then stop — open the PR into `dev` only on the user's go-ahead.
+
+```bash
+git add -A
+git commit -m "fix(readout): address review findings on the consolidated panel"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** consolidated section both `units` paths (Task 3); downloads/citation/tools + parity (Tasks 3–4, function table → `renderResources`); responsive 2-col/disclosure (Task 5); single scroll (Task 6); sticky header (Task 7); prefetch-all (Task 2); citation/pub-link helpers reused (Task 1); a11y (`aria-expanded`, real buttons) + reduced-motion + mobile truncation (Task 5); icon reuse (Task 3 classes + Task 5 styling); panel widen/opacity/bottom sheet (Task 6); verification matrix + review (Task 8). Card removal + layer-list reorg explicitly deferred (out of scope, per spec). Covered.
+- **Placeholders:** none — every code step has concrete code; every command has expected output.
+- **Type/name consistency:** `buildCitation`, `buildPubLink`, `renderResources`, `fillResources`, `getPubData`, `prefetchPubData`, `accordionFtrs`, and the CSS class names (`readout-section-body`, `readout-main`, `readout-resources`, `readout-group`/`-toggle`/`-content`, `res-downloads`/`-cite`/`-copy`/`-tools`/`-tool`/`-pan`/`-zoom`/`-share`/`-xsec`, `readout-show-more`) are used consistently across tasks. The `data-idx` lookup in Task 4 matches the `data-idx` emitted by `buildAccordion` on `.map-section-readout`.
+- **Risk note:** Task 7's class-based show/hide must replace *all* `#unitsPane` `.show()`/`.hide()` calls; a missed one would leave the panel stuck. Grep `rg "#unitsPane"` before committing Task 7 to confirm none remain on `.show()/.hide()`.

--- a/docs/specs/2026-06-06-consolidated-readout-panel-design.md
+++ b/docs/specs/2026-06-06-consolidated-readout-panel-design.md
@@ -1,0 +1,283 @@
+# Consolidated Feature Readout Panel — Design Spec
+
+**Date:** 2026-06-06
+**Status:** Proposed — design approved in discussion; pending spec review.
+**Branch:** `feat/consolidated-readout-panel` (off `dev`).
+
+## Goal
+
+Fold everything the separate "Map Downloads" card provides (downloads, citation,
+and per‑map actions) into the click‑driven unit‑description readout, so a single
+panel answers "what unit is here, from which map, and what can I do with that
+map." Use the space reclaimed from the card with a **responsive** layout, and
+collapse the readout to **one** scroll container so the multi‑scrollbar confusion
+goes away. Vanilla only — this is a stopgap ahead of the eventual MapLibre/React
+(ugs‑map‑viewer) migration; **no new libraries, no build step**.
+
+## Background — current state (on `dev`)
+
+- **Readout** (`public/mapcontrols.js`): a map click runs `fetchAttributes()`,
+  which sorts the footprints at the point and renders `buildAccordion()` into
+  `#udTab` inside `#unitsPane`. The clicked map is the open primary section; other
+  maps are collapsed accordion cards (single‑open). Each section lazy‑loads via
+  `loadSection()` → `loadUnitDescription()` (`units==='True'`) or
+  `loadPublicationOnly()` (others). Today a section shows: unit identity
+  (symbol/name/age), description, a reference line (**DOI Link** for UGS/UGMS,
+  **Publication Page** for others), and a "Show on map" layer toggle.
+- **Map Downloads** (separate mode): `#identifyPanel` toggles Unit Descriptions ↔
+  Map Downloads (`toggleUnitDesc()` / `toggleMapDl()`); Map Downloads shows the
+  footprints layer plus a Swiper carousel (`#mapsPane`) built by `printPubs()`.
+  Each carousel slide carries: a publication‑page title link, share actions
+  (shareable link, pan‑to, zoom‑to; pin / "list maps" are already hidden), the
+  citation (`reftxt`, with copy‑to‑clipboard), a preview thumbnail, and download
+  links (PDF / GIS / GeoTIFF / Cross‑section / Purchase).
+- **Data sources:**
+  - Unit description (`units==='True'`): pg_featureserv
+    `unit_desc_sym_age_by_point_scale` → `unit_symbol`, `unit_name`, `age`,
+    `unit_description`.
+  - Publication record: the Firebase `getData` function
+    (`${projectName}/getData?mapid=<series_id>`; multiple `mapid` allowed) →
+    `pub_url` (PDF), `gis_data`, `geotiff`, `x_section`, `lith_col`,
+    `bsurl`/bookstore, `pub_thumb` (preview), `pub_publisher`, `pub_author`,
+    `pub_sec_author`, `pub_year`, `pub_name`, `pub_scale`, `series_id`,
+    `quad_name`. Memoized + prefetched today by `prefetchPubData()` /
+    `getPubData()` — but only for `units!=='True'` footprints.
+  - Footprint attributes (footprints layer): `series_id`, `quad_name`, `scale`,
+    `units`, `geomaps_service`, `pub_year`, `resturl`, plus the feature geometry
+    (used for extent / pan‑zoom).
+  - Derived links: DOI `https://doi.org/10.34191/<series_id>` (UGS/UGMS);
+    publication page `https://geology.utah.gov/publication-details/?pub=<series_id>`
+    (others); purchase `https://utahmapstore.com/products/<series_id>`; file
+    downloads under `https://ugspub.nr.utah.gov/publications/<path>`.
+
+## Non‑goals (out of scope for this spec)
+
+- The **layer‑list / tools reorg** (`#layersPanel`, transparency, the footprint
+  scale‑filter buttons `#btn-*`). That is the next item‑6 sub‑project with its
+  own spec.
+- The **MapLibre/React migration**. This panel is a deliberate vanilla stopgap.
+- A fully mobile‑native experience (gesture bottom sheet, etc.) — we do a
+  pragmatic responsive treatment only.
+- Changing the data sources/endpoints or the footprint/publication schemas.
+
+## Design overview
+
+One panel, one scrollbar, **responsive disclosure**:
+
+- On a **wide** viewport the panel widens into the reclaimed card space and an
+  open section is **two columns** — description on the left, a "resources rail"
+  (publication link, downloads, citation, tools, layer toggle) on the right. The
+  rail means no expanders are needed on desktop: more is visible, fewer clicks.
+- On a **narrow** viewport the panel becomes a full‑width bottom sheet, the
+  section is **one column**, the resources collapse back into progressive‑
+  disclosure groups ("Downloads & citation", "Map tools"), and the description
+  truncates with "Show more".
+- Same DOM in both cases — CSS breakpoint flips columns ↔ stacked. No JS layout
+  branching, no library.
+
+### Responsive rules (concrete)
+
+- Breakpoint: **768px** viewport width (matches ugs‑map‑viewer's `useIsMobile`,
+  for forward consistency).
+- **≥768px (desktop):** `#unitsPane` width ≈ **440px** (up from 300px), opacity
+  raised from 0.85 → **0.96** (download/citation text must be crisp). Open
+  section body = CSS grid, two columns ≈ 60% description / 40% resources rail
+  (rail min ~165px). Description shown **in full** (it has its own column; the
+  panel scrolls if needed).
+- **<768px (mobile):** `#unitsPane` becomes a bottom‑anchored, full‑width sheet
+  (max‑height ≈ 70vh). Single column. Resources render as collapsible groups.
+  Description truncates to ~5 lines with a "Show more"/"Show less" toggle.
+- **Stretch (optional, not required for parity):** a drag handle to resize the
+  desktop panel width, persisted to `localStorage`. Marked optional so the core
+  ships without it.
+
+### Scroll model
+
+- `#unitsPane` is the **single** scroll container (`overflow-y:auto`,
+  `max-height`). No inner `vh`‑capped scroll boxes (removes the
+  `.map-readout` / `.readout-others` / `.map-section-readout` nested scrolls that
+  caused the multi‑scrollbar confusion and the zoom clipping).
+- Because every section is compact by default (full‑but‑single‑column or
+  two‑column rail; expanders collapsed on mobile; description truncated on
+  mobile), the clicked map and the collapsed "other maps" headers fit with one
+  scrollbar; you only scroll when you deliberately expand/expand a long
+  description.
+- The **panel header** (clicked‑map title + close ✕) is `position:sticky` at the
+  top of the scroll container, so close is always reachable (also resolves the
+  earlier "close button scrolls away" issue).
+
+## Section anatomy
+
+### `units==='True'` (has a unit description)
+
+Header (accordion trigger): `1:24,000 · Provo · M-249 · 1991` + chevron + (when
+its category has a real layer) the "Show on map" toggle.
+
+Open body:
+- **Unit identity:** `Qal: Alluvium (Holocene)` (`.unit-desc-title`).
+- **Description:** full on desktop; truncated + "Show more" on mobile.
+- **Resources** (rail on desktop / collapsible groups on mobile):
+  - **Publication link:** "DOI Link" (UGS/UGMS) or "Publication Page" (others) —
+    the existing publisher‑aware logic.
+  - **Downloads:** PDF · GIS data · GeoTIFF · Cross‑section · Purchase — only the
+    ones present for that map; each an icon + label (see Icon reuse). Cross‑
+    section opens the existing image viewer (`#xsection-pane`).
+  - **Citation:** the `reftxt` string (author[, and sec_author], year, name,
+    series_id, publisher, scale) with a copy‑to‑clipboard control.
+  - **Map tools:** Pan to · Zoom to (the map's footprint extent) · Copy shareable
+    link · Preview (thumbnail from `pub_thumb`).
+
+### `units!=='True'` (publication‑only; no unit description)
+
+- No left description column → the section leads with the resources (downloads
+  are the point). Keep the short note "Tabular GIS data has not been generated
+  for this map; see the publication." + the publication link, then Downloads /
+  Citation / Map tools as above.
+- On desktop this is effectively a single wide resources block (no 2‑col split).
+
+### "Other maps at this location"
+
+- Unchanged structure: a single‑open accordion of collapsed headers below the
+  primary. Opening one gives it the same responsive section body. The clicked
+  map remains the default‑open primary on top.
+
+## Functions carried over from the Map Downloads card
+
+| Card function | New home | Source |
+|---|---|---|
+| Publication page title link | Resources → publication link | derived (publisher) |
+| PDF | Downloads | `getData.pub_url` |
+| GIS data | Downloads | `getData.gis_data` |
+| GeoTIFF | Downloads | `getData.geotiff` |
+| Cross‑section (+ viewer) | Downloads (opens `#xsection-pane`) | `getData.x_section` |
+| Purchase | Downloads | `utahmapstore.com/products/<series_id>` (gated by `bsurl`) |
+| Citation (+ copy) | Resources → citation | `reftxt` (reuse, incl. sec‑author join) |
+| Preview image | Map tools → Preview | `getData.pub_thumb` |
+| Shareable link | Map tools | existing `?view=scene&sid=…&layers=…` + `copyToClipboard` |
+| Pan to / Zoom to | Map tools | footprint feature extent |
+| Footprint highlight | automatic on section open/hover | footprint geometry |
+| Pin / "list maps on screen" | dropped | already hidden today |
+
+## Icon reuse
+
+Reuse the existing download glyph classes from the card (`pdfIcon`, `gisIcon`,
+`tiffIcon`, `xsecIcon`, `purIcon`) and the existing tool/share icon styles so the
+consolidated panel matches the app and needs **no new assets**. The cross‑section
+download reuses the current `#xsection-pane` viewer wiring.
+
+## DOM / CSS approach
+
+- Extend `buildAccordion()` section markup to emit the resources block. New
+  containers (illustrative class names): `.readout-resources` (the rail/groups
+  wrapper), `.readout-downloads`, `.readout-citation`, `.readout-tools`, plus
+  disclosure groups `.readout-group[aria-expanded]` for the mobile collapsibles.
+- Responsive layout via a CSS grid on the open section body
+  (`grid-template-columns: 1fr` mobile → `minmax(0,1.4fr) minmax(165px,1fr)`
+  desktop) behind the 768px media query. The mobile collapsibles are hidden
+  on desktop (the rail shows the same content expanded) — same content, CSS
+  controls presentation.
+- Remove the nested `vh` scroll caps introduced for the pinned layout; make
+  `#unitsPane` the single scroller; make the header sticky.
+- Keep all rendering in `mapcontrols.js`/`style.css` (the established single‑file
+  pattern); no framework, no build.
+
+## Data fetching
+
+- Extend `prefetchPubData()` to warm `getData` for **all** footprints at the
+  point (not just `units!=='True'`), since every section now shows
+  downloads/citation. `getData` already accepts batched `mapid`s and the result
+  is memoized by `series_id`.
+- The DOI/Publication‑Page link renders immediately from `series_id` +
+  publisher; file downloads/citation/preview render when the (prefetched)
+  `getData` record resolves.
+- Reuse the citation builder (the `pub_author` + smart‑"and" `pub_sec_author`
+  join already added in PR #144) — extract it into a small shared helper so both
+  the readout and (temporarily) `printPubs` use one implementation.
+
+## Accessibility & polish ("make it awesome")
+
+- Disclosure groups are real buttons with `aria-expanded`/`aria-controls`;
+  keyboard operable; visible focus rings (the accordion already does this).
+- Smooth height/opacity transitions on expand/collapse and on the description
+  "Show more".
+- Crisp typography hierarchy: section header (Bebas) > unit identity (the smaller
+  weight from PR #144) > body; downloads as scannable icon+label rows; citation
+  in a muted, monospace‑free small style with an obvious copy affordance.
+- Loading and empty states per section (spinner while `getData` resolves;
+  graceful "no downloads available" when a map has none).
+- Respect `prefers-reduced-motion` for the transitions.
+
+## Retiring Map Downloads (sequenced follow‑up — not this spec's build)
+
+Once a consolidated section reaches parity with the card (verified on the dev
+site), a small follow‑up removes the `#identifyPanel` toggle,
+`toggleUnitDesc()`/`toggleMapDl()`, the `#mapsPane` Swiper, and `printPubs()`,
+and makes the readout the single experience. Kept separate so we don't delete the
+card until parity is proven, and so the footprints‑layer / scale‑filter‑button
+handling can be addressed with the layer‑list reorg. The citation's only other
+home is the readout, so it must be live there first.
+
+## Tech constraints
+
+- Vanilla JS (ArcGIS Maps SDK + jQuery), Firebase Hosting + Cloud Functions,
+  pg_featureserv, AGOL footprints. No new runtime dependency. No build step.
+- `node --check public/mapcontrols.js` must pass; CSS brace‑balanced.
+
+## Testing (manual — no frontend test runner in this repo)
+
+Verify on the **dev site** (auto‑deploys from `dev`); local `firebase serve`
+can't render the secured ArcGIS geology layers (see auto‑memory). Cases:
+- Desktop ≥768px: two‑column section; full description; rail shows publication
+  link + downloads + citation (copy works) + tools (pan/zoom/share/preview);
+  single scrollbar; sticky header/close.
+- Mobile <768px: bottom sheet; one column; description truncates with Show
+  more; resources collapse into groups; single scrollbar.
+- A `units==='True'` map (e.g. `M-300DM`): description + DOI Link + downloads.
+- A `units!=='True'` UGS/UGMS map (`Q-2thru5`): Publication‑only note + DOI Link
+  + PDF/GeoTIFF + citation incl. secondary authors.
+- A non‑UGS map (`I-2462`, USGS): Publication Page (not DOI) + whatever
+  downloads exist.
+- Multiple maps at a point: accordion of others; opening one renders the same
+  responsive body; clicked map stays the default‑open primary.
+- Zoom Chrome to ~150–175%: nothing clipped; one scrollbar.
+
+## Decisions (resolved)
+
+- Density: compact, progressive disclosure.
+- Responsive: columns on desktop / stacked + expanders on mobile, 768px.
+- Description: full on desktop, truncate on mobile.
+- Panel: ~440px desktop / full‑width bottom sheet mobile; opacity → 0.96.
+- Scroll: single container + sticky header.
+- Drag‑to‑resize: optional stretch, not required for parity.
+- Map Downloads removal: sequenced follow‑up after parity.
+
+## Open questions
+
+- None blocking. (Exact desktop width, rail ratio, and truncation line‑count are
+  tunable during implementation against the dev site.)
+
+## Risks
+
+- Two readout render paths (`loadUnitDescription` / `loadPublicationOnly`) must
+  both adopt the resources block without regressing the existing description /
+  500k / Macrostrat / out‑of‑state paths.
+- Prefetching `getData` for all footprints slightly increases requests at click
+  time (bounded by # maps at a point; memoized) — acceptable.
+- The footprint feature geometry must be retained through `accordionFtrs` for
+  pan/zoom/extent; confirm `returnGeometry` on the click query during
+  implementation.
+- This is throwaway at migration — keep it contained; resist scope creep into the
+  layer‑list reorg.
+
+## Self‑review
+
+- Spec coverage: consolidated section (anatomy, both `units` paths), responsive
+  columns + disclosure, single‑scroll + sticky header, function parity table +
+  data sources, icon reuse, prefetch extension, citation helper extraction,
+  a11y/polish, retirement sequencing, testing, constraints. Covered.
+- Placeholders: none.
+- Consistency: 768px breakpoint, ~440px width, 0.96 opacity, and the single‑
+  scroll model are stated once and reused; function table maps every card
+  feature to a home + source.
+- Scope: focused on the consolidated readout + scroll; layer‑list reorg and the
+  actual card removal are explicitly deferred.

--- a/functions/index.js
+++ b/functions/index.js
@@ -159,6 +159,10 @@ exports.getArcGISToken = onCall({
     const ALLOWED_REFERERS = [
       /^https:\/\/geomap\.geology\.utah\.gov$/,
       /^https:\/\/ut-dnr-ugs-geolmapportal-(prod|dev)\.web\.app$/,
+      // ONE dedicated, team-controlled dev preview channel for reviewing in-progress branches
+      // with the secured layers. Same exposure as the dev site (a single known URL). Scoped to
+      // this channel name only -- other ephemeral PR-preview channels stay excluded (see note).
+      /^https:\/\/ut-dnr-ugs-geolmapportal-dev--readout-panel-[a-z0-9]+\.web\.app$/,
       /^http:\/\/localhost(:\d+)?$/,
       /^http:\/\/127\.0\.0\.1(:\d+)?$/
     ];

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2108,6 +2108,54 @@ function buildCitation(rec) {
     return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + '. 1:' + scaleInt + ',000 scale.';
 }
 
+// the resources block (publication link, downloads, citation, map tools) for one section.
+// rec is the getData record (may be null while loading / if the map has no record).
+function renderResources(rec, atts) {
+    var sid = atts.series_id;
+    var pubLink = '<div class="res-publink">' + buildPubLink(sid, rec) + '</div>';
+
+    var dl = [];
+    if (rec && rec.pub_url)   dl.push('<a class="downloadList pdfIcon"  target="_blank" href="' + rec.pub_url + '">PDF</a>');
+    if (rec && rec.gis_data)  dl.push('<a class="downloadList gisIcon"  target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.gis_data + '">GIS data</a>');
+    if (rec && rec.geotiff)   dl.push('<a class="downloadList tiffIcon" target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
+    if (rec && rec.x_section) dl.push('<a class="downloadList xsecIcon res-xsec" href="#" data-xsec="' + rec.x_section + '">Cross-section</a>');
+    if (rec && rec.bsurl)     dl.push('<a class="downloadList purIcon" target="_blank" href="https://utahmapstore.com/products/' + sid + '">Purchase</a>');
+    var downloads = dl.length
+        ? '<div class="res-downloads">' + dl.join('') + '</div>'
+        : '<div class="res-empty">No downloads available for this map.</div>';
+
+    var citeText = rec ? buildCitation(rec) : '';
+    var cite = citeText
+        ? '<div class="res-cite"><span class="res-cite-text">' + citeText + '</span>' +
+          '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
+        : '';
+
+    var tools = '<div class="res-tools">' +
+        '<button type="button" class="res-tool res-pan"   title="Pan to this map">Pan to</button>' +
+        '<button type="button" class="res-tool res-zoom"  title="Zoom to this map">Zoom to</button>' +
+        '<button type="button" class="res-tool res-share" title="Copy a shareable link">Copy link</button>' +
+        '</div>';
+
+    var dlOpen = (atts.units === 'True') ? '' : ' open';   // pub-only maps lead with downloads
+    return pubLink +
+        '<div class="readout-group readout-group-dl' + dlOpen + '">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="' + (dlOpen ? 'true' : 'false') + '">Downloads &amp; citation</button>' +
+            '<div class="readout-group-content">' + downloads + cite + '</div>' +
+        '</div>' +
+        '<div class="readout-group readout-group-tools">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="false">Map tools</button>' +
+            '<div class="readout-group-content">' + tools + '</div>' +
+        '</div>';
+}
+
+// fill a section's .readout-resources once the (prefetched) getData record resolves
+function fillResources(atts, container) {
+    if (!container) return;
+    getPubData(atts.series_id)
+        .then(function (rec) { if (container.isConnected) container.innerHTML = renderResources(rec, atts); })
+        .catch(function () { if (container.isConnected) container.innerHTML = renderResources(null, atts); });
+}
+
 // publisher-aware publication link: UGS/UGMS -> our DOI; other publishers -> the UGS catalog
 // page (we host the page but not their DOI, so it must not be labeled a DOI link).
 function buildPubLink(seriesId, rec) {
@@ -2325,9 +2373,15 @@ function loadUnitDescription(atts, evt, bodyEl) {
         var desc = unit.unit_description;
         if (scale === '500k') desc = "Only unit symbol and unit name are available at the statewide 1:500,000 scale.";
         bodyEl.innerHTML =
-            '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
-            '<div class="unit-desc-text">' + desc + '</div>' +
-            '<div class="unit-desc-ref">&bull;<a target="_blank" href="https://doi.org/10.34191/' + atts.series_id + '">DOI Link</a></div>';
+            '<div class="readout-section-body">' +
+                '<div class="readout-main">' +
+                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
+                    '<div class="unit-desc-text">' + desc + '</div>' +
+                    '<button type="button" class="readout-show-more">Show more</button>' +
+                '</div>' +
+                '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+            '</div>';
+        fillResources(atts, bodyEl.querySelector('.readout-resources'));
     }).catch(function (err) {
         if (bodyEl.isConnected) bodyEl.innerHTML = '<div class="unit-desc-text">Could not load the unit description.</div>';
         console.error('unit description fetch failed for ' + atts.series_id + ':', err);
@@ -2359,33 +2413,14 @@ function prefetchPubData(ftrs) {
     }
 }
 
-// load a units=False map's publication links into the given section body
+// load a units=False map's publication-only section (no unit description)
 function loadPublicationOnly(atts, bodyEl) {
-    var sid = atts.series_id;
-    function paint(rec) {
-        if (!bodyEl.isConnected) return;
-        var links = [];
-        // the publisher decides both the label and the URL, so only emit the catalog link
-        // once we have the record (rec is null on the first, pre-fetch paint).
-        if (rec) {
-            var pub = (rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
-            var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
-            // UGS/UGMS: link our DOI (we are the registrant). Maps published by others
-            // (e.g. USGS): we host a catalog page but not their DOI, so link the UGS
-            // publication page and don't call it a DOI link.
-            links.push(isUgs
-                ? '<a target="_blank" href="https://doi.org/10.34191/' + sid + '">DOI Link</a>'
-                : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + sid + '">Publication Page</a>');
-            if (rec.pub_url) links.push('<a target="_blank" href="' + rec.pub_url + '">PDF</a>');
-            if (rec.geotiff) links.push('<a target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
-        }
-        var linkHtml = links.length ? ('<div class="unit-desc-ref">' + links.join('&nbsp;&middot;&nbsp;') + '</div>') : '';
-        bodyEl.innerHTML = '<div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div>' + linkHtml;
-    }
-    paint(null);
-    getPubData(sid).then(paint).catch(function (err) {
-        console.error('getPubData failed for ' + sid + ':', err);
-    });
+    bodyEl.innerHTML =
+        '<div class="readout-section-body readout-pubonly">' +
+            '<div class="readout-main"><div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div></div>' +
+            '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+        '</div>';
+    fillResources(atts, bodyEl.querySelector('.readout-resources'));
 }
 
 // add a default map marker when user clicks map

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2456,6 +2456,17 @@ $(document).on('click', '#udTab .res-tool', function (e) {
     }
 });
 
+// resources: toggle a disclosure group (mobile); description show more/less (mobile)
+$(document).on('click', '#udTab .readout-group-toggle', function () {
+    var open = this.parentNode.classList.toggle('open');
+    this.setAttribute('aria-expanded', open ? 'true' : 'false');
+});
+$(document).on('click', '#udTab .readout-show-more', function () {
+    var main = this.closest('.readout-main');
+    if (!main) return;
+    this.textContent = main.classList.toggle('expanded') ? 'Show less' : 'Show more';
+});
+
 // add a default map marker when user clicks map
 // to show where fm chosen is...
 function addFmMarker(lng,lat){

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -1422,7 +1422,7 @@ $(".map-downloads").click(function () {
     toggleMapDl();
 });
 function toggleMapDl(){
-    $("#unitsPane").hide();
+    $("#unitsPane").addClass("hidden");
     ( map.findLayerById('footprints') ) ? map.findLayerById('footprints').visible = true : addFootprints();
     //if ($('#footprints').is(':checked') == false) $('#footprints').click();  // needs to trigger .change event
     document.getElementById("footprints").disabled = false;
@@ -1455,7 +1455,7 @@ $(".geocoder").click(function () {
 //close when clicking x
 $("#fms-close").click(function () {
     //$("#unitsPane").addClass("hidden");
-    $("#unitsPane").hide();
+    $("#unitsPane").addClass("hidden");
     view.graphics.removeAll();
 });
 
@@ -1933,7 +1933,7 @@ view.on("click", function (evt) {
             {
                 html = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;fetching unit description...</div>';
                 byId('udTab').innerHTML = html;
-                $("#unitsPane").show();
+                $("#unitsPane").removeClass("hidden");
                 fetchAttributes(ftrset,evt);
     
             } else if ($(".map-downloads").hasClass("selected"))  // MAP DOWNLOADS
@@ -1950,7 +1950,7 @@ view.on("click", function (evt) {
     .catch((error) => {
         console.log("Acrgis online Server erro. Server said: ", error);
         byId('udTab').innerHTML = "<div>Server is grumpy. We'll tickle his belly and you can try again in a second.</div>";
-        //$("#unitsPane").hide();
+        //$("#unitsPane").addClass("hidden");
     });
 });    
 */
@@ -2025,7 +2025,7 @@ function queryUnits(evt){
         {
             html = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;fetching unit description...</div>';
             byId('udTab').innerHTML = html;
-            $("#unitsPane").show();
+            $("#unitsPane").removeClass("hidden");
             fetchAttributes(ftrset,evt);
 
         } 
@@ -2033,7 +2033,7 @@ function queryUnits(evt){
     .catch(function (error) {
     //console.log("Acrgis online Server erro. Server said: ", error);
     byId('udTab').innerHTML = "<div>Server is grumpy. We'll tickle his belly and you can try again in a second.</div>";
-    //$("#unitsPane").hide();
+    //$("#unitsPane").addClass("hidden");
     }); 
 }
 
@@ -2061,7 +2061,7 @@ function printMSFms(sdata)
 {
     // redo this .append the right way.
 	$.each(sdata.mapData, function(i, sdx) {
-       $("#unitsPane").show();
+       $("#unitsPane").removeClass("hidden");
 
        var unidesc = '<div>' + '<div class="unit-desc-title">' + sdx.name + '</div><div class="unit-age">(' + sdx.age + ')</div>' + '<hr>' + 
             '<div class="unit-desc-text">' + sdx.descrip + '</div>' + 

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2344,10 +2344,7 @@ function getPubData(seriesId) {
     var url = projectName + '/getData?mapid=' + encodeURIComponent(seriesId);
     var p = fetch(url)
         .then(function (r) { if (!r.ok) throw new Error('getData ' + r.status); return r.json(); })
-        .then(function (data) {
-            var rec = (data && data[0]) ? data[0] : null;
-            return rec ? { pub_url: rec.pub_url, geotiff: rec.geotiff, pub_publisher: rec.pub_publisher } : null;
-        });
+        .then(function (data) { return (data && data[0]) ? data[0] : null; });
     p.catch(function () { delete pubDataCache[seriesId]; });
     pubDataCache[seriesId] = p;
     return p;
@@ -2357,8 +2354,8 @@ function getPubData(seriesId) {
 // their links are already loaded by the time the user opens that section (item: faster links)
 function prefetchPubData(ftrs) {
     for (var i = 0; i < ftrs.length; i++) {
-        var a = ftrs[i].attributes;
-        if (a.units !== 'True' && a.series_id) getPubData(a.series_id).catch(function () {});
+        var sid = ftrs[i].attributes.series_id;
+        if (sid) getPubData(sid).catch(function () {});
     }
 }
 

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2423,6 +2423,39 @@ function loadPublicationOnly(atts, bodyEl) {
     fillResources(atts, bodyEl.querySelector('.readout-resources'));
 }
 
+// resources: copy citation
+$(document).on('click', '#udTab .res-copy', function (e) {
+    e.preventDefault();
+    copyToClipboard(decodeURIComponent(this.getAttribute('data-cite') || ''));
+});
+// resources: open the cross-section in the existing image viewer
+$(document).on('click', '#udTab .res-xsec', function (e) {
+    e.preventDefault();
+    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('#xsection-pane').removeClass('hidden');
+});
+// resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx
+$(document).on('click', '#udTab .res-tool', function (e) {
+    e.preventDefault();
+    var host = this.closest('[data-idx]');
+    if (!host) return;
+    var ftr = accordionFtrs[parseInt(host.getAttribute('data-idx'), 10)];
+    if (!ftr || !ftr.geometry) return;
+    var ext = ftr.geometry.extent;
+    if (this.classList.contains('res-pan') && ext) {
+        view.center = ext.center;
+    } else if (this.classList.contains('res-zoom') && ext) {
+        view.extent = ext;
+        view.zoom = view.zoom - 1;
+    } else if (this.classList.contains('res-share')) {
+        var sid = ftr.attributes.series_id;
+        var sc = parseInt(ftr.attributes.scale);
+        var lyrs = (sc <= 24) ? '24k' : (sc < 250) ? '100k' : '500k';
+        var base = window.location.href.split('#')[0].split('?')[0];
+        copyToClipboard(encodeURI(base + '?view=scene&sid=' + sid + '&layers=' + lyrs));
+    }
+});
+
 // add a default map marker when user clicks map
 // to show where fm chosen is...
 function addFmMarker(lng,lat){

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2093,6 +2093,31 @@ function displaySeriesId(id) {
     return id;
 }
 
+// citation string for a publication record (shared by the readout + the downloads carousel).
+// pub_sec_author is free text that may already contain "and" + multiple names (e.g.
+// "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't already have one.
+function buildCitation(rec) {
+    if (!rec) return '';
+    var authors = rec.pub_author || '';
+    if (rec.pub_sec_author) {
+        var sec = String(rec.pub_sec_author).trim();
+        if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
+    }
+    var scaleInt = scaleToInt(rec.pub_scale);
+    var publisher = rec.pub_publisher ? rec.pub_publisher : '';
+    return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + '. 1:' + scaleInt + ',000 scale.';
+}
+
+// publisher-aware publication link: UGS/UGMS -> our DOI; other publishers -> the UGS catalog
+// page (we host the page but not their DOI, so it must not be labeled a DOI link).
+function buildPubLink(seriesId, rec) {
+    var pub = (rec && rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
+    var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
+    return isUgs
+        ? '<a target="_blank" href="https://doi.org/10.34191/' + seriesId + '">DOI Link</a>'
+        : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + seriesId + '">Publication Page</a>';
+}
+
 // the functional layer-toggle for a footprint, or null if its category has no working
 // layer (geomaps_irreg / geomaps_1x2 -- these never gate the readout via a checkbox)
 function footprintToggle(attrs) {
@@ -2572,15 +2597,7 @@ var printPubs = function(pubResults){
         $( titleArea ).append( '<p class="mapInfo">'+ info +'</p>' );
         $( titleArea ).append( '<p class="mapScale">'+ scaleInt +'k</p>' );
         var publisher = (arr.pub_publisher) ? arr.pub_publisher : "";
-        // pub_sec_author is free text that may already include "and" + multiple names
-        // (e.g. "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't
-        // already have one -- avoids "Stokes, and Hintze, and Madsen".
-        var authors = arr.pub_author;
-        if (arr.pub_sec_author) {
-            var sec = String(arr.pub_sec_author).trim();
-            if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
-        }
-        var reftxt = authors +', '+ arr.pub_year +', '+ arr.pub_name +'. '+ arr.series_id +'. '+ publisher +'. 1:'+ scaleInt +',000 scale.';
+        var reftxt = buildCitation(arr);
         var copydiv = $('<p class="mapRef smallscroll tooltip ref-right" data-title="click to copy map reference"><span id="copyRef" data-title="copy reference" title="copy reference to clip board" class="esri-icon-duplicate"></span>&nbsp;'+ reftxt +'</p><br><br>');
         copydiv.click(function(n) {
             //console.log('copy to clipboard');

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2103,9 +2103,10 @@ function buildCitation(rec) {
         var sec = String(rec.pub_sec_author).trim();
         if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
     }
-    var scaleInt = scaleToInt(rec.pub_scale);
+    var scaleInt = rec.pub_scale ? scaleToInt(rec.pub_scale) : '';
     var publisher = rec.pub_publisher ? rec.pub_publisher : '';
-    return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + '. 1:' + scaleInt + ',000 scale.';
+    var scaleClause = scaleInt ? ('. 1:' + scaleInt + ',000 scale.') : '.';
+    return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + scaleClause;
 }
 
 // the resources block (publication link, downloads, citation, map tools) for one section.

--- a/public/style.css
+++ b/public/style.css
@@ -2225,7 +2225,7 @@ p:last-child {
 
 @media (min-width: 768px) {
     .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(165px, 1fr); gap: 12px; }
-    .readout-pubonly .readout-section-body { grid-template-columns: 1fr; }
+    .readout-section-body.readout-pubonly { grid-template-columns: 1fr; }
     .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
     .readout-group-content { display: block; }
     .readout-group { margin-top: 10px; }

--- a/public/style.css
+++ b/public/style.css
@@ -2189,3 +2189,48 @@ p:last-child {
 .map-section.layer-off .map-section-title { color: #a6a6a6; }
 .layer-off .desc-badge { fill: #bcbcbc; }
 .map-section.layer-off .map-section-chevron { border-color: #c4c4c4; }
+
+/* consolidated section: stacked by default; two columns on desktop (media query below) */
+.readout-section-body { display: block; }
+.readout-main, .readout-resources { min-width: 0; }
+
+.res-publink { font-size: 11px; margin: 4px 0; }
+.res-downloads { display: flex; flex-direction: column; gap: 3px; margin: 4px 0; }
+.res-downloads .downloadList { font-size: 12px; line-height: 18px; }
+.res-empty { font-size: 11px; color: #9a9a9a; margin: 4px 0; }
+
+.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 10px; line-height: 13px; color: #555; }
+.res-cite-text { flex: 1; }
+.res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
+
+.res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.res-tool { font-size: 11px; padding: 3px 8px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
+.res-tool:hover { background: #eceff4; }
+
+/* disclosure groups: collapsible on mobile, always-open rail on desktop */
+.readout-group { margin-top: 8px; }
+.readout-group-toggle { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; border: none; background: none; padding: 4px 0; cursor: pointer; font: 600 12px "Avenir Next W00", Helvetica, Arial, sans-serif; color: #4a4a4a; }
+.readout-group-toggle::before { content: "\25B8"; font-size: 9px; transition: transform .15s ease; }
+.readout-group.open .readout-group-toggle::before { transform: rotate(90deg); }
+.readout-group-content { display: none; padding-left: 2px; }
+.readout-group.open .readout-group-content { display: block; }
+
+.readout-show-more { display: none; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
+
+@media (min-width: 768px) {
+    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(165px, 1fr); gap: 12px; }
+    .readout-pubonly .readout-section-body { grid-template-columns: 1fr; }
+    .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
+    .readout-group-content { display: block; }
+    .readout-group { margin-top: 10px; }
+}
+
+@media (max-width: 767px) {
+    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
+    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
+    .readout-show-more { display: inline-block; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .readout-group-toggle::before { transition: none; }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1463,14 +1463,24 @@ p:last-child {
     bottom: 0px;
     right: -5px;
     max-height:75vh;
-    width: 300px;
+    width: 440px;
     z-index: 99;
     border-radius: 6px;
     padding: 8px;
     margin: 5px;
-    overflow-y: auto;
-    opacity: 0.85;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    opacity: 0.96;
     background-color: white;
+}
+/* #udTab is the single scroll container; the close button (absolute in #unitsPane) stays pinned */
+#udTab { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+#dlTab { flex: none; }
+#unitsPane.hidden { display: none; }   /* beat the id-specificity of display:flex when hidden */
+
+@media (max-width: 767px) {
+    #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }
 }
 
 .unit-desc-title {
@@ -2135,26 +2145,23 @@ p:last-child {
 
 } /*  end @media for mobile */
 
-/* unit-readout: the clicked map pinned at top as the answer + the other maps as a single-open
-   accordion below. .map-readout is height-bounded so the primary description scrolls in its own
-   box and the "other maps" section stays pinned at the bottom. Its cap is kept strictly inside
-   #unitsPane (max-height:75vh) minus that pane's 16px padding (plus a buffer), so #unitsPane
-   itself never has to scroll the accordion and the bottom section can't be clipped -- including
-   at high browser zoom, where the fixed padding used to overrun the old, too-close 72vh/75%. */
-.map-readout { display: flex; flex-direction: column; max-height: calc(75vh - 30px); font-size: 13px; }
+/* unit-readout: the clicked map (open primary) on top + the other maps as a single-open
+   accordion below. Sections are compact (progressive disclosure), so the readout flows
+   naturally and #udTab is the single scroll container (see the #udTab / #unitsPane rules) --
+   no nested vh-capped scroll boxes. One scrollbar, and nothing clips at high browser zoom. */
+.map-readout { font-size: 13px; }
 
-/* primary = the clicked map, pinned at the top; its description scrolls within a capped box */
-.readout-primary { flex: 0 1 auto; min-height: 0; display: flex; flex-direction: column; padding: 0 2px; }
-.readout-primary-head { flex: none; padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+/* primary = the clicked map, open on top */
+.readout-primary { padding: 0 2px; }
+.readout-primary-head { padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
 .readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
-.readout-primary .map-section-readout { flex: 1 1 auto; min-height: 0; max-height: 45vh; overflow-y: auto; overscroll-behavior: contain; }
 
-/* the other maps, pinned in their own scrollable section below the primary */
-.readout-others { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; overscroll-behavior: contain; border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
-.other-maps-label { flex: none; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
+/* the other maps, listed below the primary */
+.readout-others { border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
+.other-maps-label { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
 
 /* other-map cards (collapsed headers, single-open) */
-.map-section { flex: none; border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
+.map-section { border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
 .map-section:hover { background: #eceff4; }
 .map-section.open { background: #fff; border-color: #d4dde7; box-shadow: 0 1px 5px rgba(50,106,152,.12); }
 .map-section-header { display: flex; align-items: center; gap: 8px; padding: 7px 9px; cursor: pointer; }
@@ -2169,7 +2176,6 @@ p:last-child {
 
 .map-section-body { display: none; padding: 0 10px 9px; }
 .map-section.open .map-section-body { display: block; }
-.map-section.open .map-section-readout { max-height: 30vh; overflow-y: auto; overscroll-behavior: contain; }
 
 /* layer toggle switch (on = accent blue), behaves like a layer-list checkbox */
 .layer-switch { display: inline-flex; align-items: center; gap: 7px; margin-top: 9px; cursor: pointer; font-size: 11px; color: #6a6a6a; user-select: none; }


### PR DESCRIPTION
## Summary
Item 6, part 1: folds the Map Downloads card's functions into the click-driven readout (vanilla; no new libraries). Each map section now carries its publication link, downloads (PDF / GIS / GeoTIFF / cross-section / purchase), citation, and map tools (pan / zoom / copy-link), with a responsive two-column layout on desktop and a stacked, progressively-disclosed layout on mobile, in a single-scroll panel with a pinned header.

Spec: `docs/specs/2026-06-06-consolidated-readout-panel-design.md` · Plan: `docs/plans/2026-06-06-consolidated-readout-panel.md`

Also includes a small `functions/index.js` change: allowlist one dedicated dev preview channel (`readout-panel`) in `getArcGISToken`'s `ALLOWED_REFERERS` so an in-progress branch can be reviewed with the secured layers (scoped to that one channel; other ephemeral previews stay excluded).

## What changed
- `buildCitation` / `buildPubLink` helpers (shared by readout + downloads carousel)
- `getPubData` returns the full record + prefetch for all footprints at the point
- `renderResources()` injected per section; delegated handlers for copy / cross-section / pan / zoom / share + disclosure toggles
- Responsive CSS (768px): 2-col rail on desktop, collapsible groups + clamped description on mobile; single-scroll panel widened to 440px / bottom sheet; `#unitsPane` flex + class-based show/hide so the close button stays pinned

## Test plan (verify on the dev site after merge)
- [ ] Desktop ≥768px: two-column section, full description, rail (publication link + downloads + citation copy + pan/zoom/copy-link); single scrollbar; pinned close
- [ ] Mobile <768px: bottom sheet, one column, description "Show more", collapsible groups
- [ ] `M-300DM` → DOI Link + downloads; `Q-2thru5` (UGMS) → DOI Link + PDF/GeoTIFF + multi-author citation; `I-2462` (USGS) → Publication Page
- [ ] Multiple maps at a point; cross-section opens the viewer; copy-link yields `?view=scene&sid=…&layers=…`
- [ ] Chrome zoom ~150–175%: nothing clipped, one scrollbar

## Notes
- Self-reviewed plus a final review agent (one real bug fixed: pub-only single-column selector; citation hardened against null scale). `node --check` + CSS brace balance pass on every commit.
- Could not browser-verify locally (secured layers) — the dev site is the verification surface.