### PR TITLE
feat(ci): dynamic per-PR preview-channel allowlist for secured layers

### DIFF
--- a/.github/scripts/preview-referer.js
+++ b/.github/scripts/preview-referer.js
@@ -1,0 +1,33 @@
+// CI helper: maintain the `previewReferers` allowlist (one doc per open PR) that the
+// getArcGISToken function reads to grant secured-layer tokens to open PRs' preview channels.
+//   node preview-referer.js add <prNumber> <channelUrl>
+//   node preview-referer.js remove <prNumber>
+// Auth: GOOGLE_APPLICATION_CREDENTIALS must point to a prod service-account key.
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+const [, , action, pr, url] = process.argv;
+if (!action || !pr) {
+  console.error('usage: preview-referer.js <add|remove> <prNumber> [channelUrl]');
+  process.exit(1);
+}
+
+const ref = admin.firestore().collection('previewReferers').doc(String(pr));
+
+(async () => {
+  if (action === 'add') {
+    if (!url) { console.error('add requires a channelUrl'); process.exit(1); }
+    await ref.set({
+      url: url.replace(/\/+$/, ''),
+      pr: Number(pr),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+    console.log('allowlisted preview channel for PR', pr, '->', url);
+  } else if (action === 'remove') {
+    await ref.delete(); // idempotent: deleting a missing doc is a no-op
+    console.log('removed preview-channel allowlist entry for PR', pr);
+  } else {
+    console.error('unknown action:', action);
+    process.exit(1);
+  }
+})().catch((err) => { console.error(err); process.exit(1); });

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -18,9 +18,24 @@ jobs:
           echo "PROJECT_ID=ut-dnr-ugs-geolmapportal-dev" >> $GITHUB_ENV
           
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        id: deploy
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets[env.FIREBASE_SERVICE_ACCOUNT] }}'
           projectId: '${{ env.PROJECT_ID }}'
           expires: 6d
+
+      # Add this PR's preview-channel URL to the secured-layer allowlist (prod Firestore) so the
+      # getArcGISToken function will mint a token bound to it. Removed on PR close (cleanup workflow).
+      - name: Allowlist this PR's preview channel for secured layers
+        if: ${{ steps.deploy.outputs.details_url != '' }}
+        env:
+          PROD_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_PROD }}
+          CHANNEL_URL: ${{ steps.deploy.outputs.details_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          printf '%s' "$PROD_SA" > "$RUNNER_TEMP/prod-sa.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/prod-sa.json"
+          npm i --no-save firebase-admin@13
+          node .github/scripts/preview-referer.js add "$PR_NUMBER" "$CHANNEL_URL"
 

--- a/.github/workflows/preview-referer-cleanup.yml
+++ b/.github/workflows/preview-referer-cleanup.yml
@@ -1,0 +1,27 @@
+name: Clean up preview referer on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    # only our own branches (skip forks), and skip the dev->master promotion PRs
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the helper script lives on the base branch by the time PRs close
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Remove this PR's preview channel from the secured-layer allowlist
+        env:
+          PROD_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_PROD }}
+        run: |
+          printf '%s' "$PROD_SA" > "$RUNNER_TEMP/prod-sa.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/prod-sa.json"
+          npm i --no-save firebase-admin@13
+          node .github/scripts/preview-referer.js remove "${{ github.event.pull_request.number }}"

--- a/docs/specs/2026-06-06-dynamic-preview-allowlist-design.md
+++ b/docs/specs/2026-06-06-dynamic-preview-allowlist-design.md
@@ -1,0 +1,122 @@
+# Dynamic Preview-Channel Allowlist for Secured Layers — Design Spec
+
+**Date:** 2026-06-06
+**Status:** Proposed — approved in discussion.
+**Branch:** `feat/dynamic-preview-allowlist` (off `dev`).
+
+## Goal
+
+Every **open-PR** dev preview channel can load the secured ArcGIS layers —
+automatically, with the referer allowlist staying **tight** (static origins +
+only currently-open-PR channels) and **self-cleaning** (an entry is removed when
+its PR closes). No per-PR prod function deploys, and the manual `readout-panel`
+channel is retired.
+
+## Background (current state)
+
+- `getArcGISToken` (`functions/index.js`) mints a **referer-bound** ArcGIS token.
+  It only binds the token to the caller's origin when that origin matches a
+  hard-coded `ALLOWED_REFERERS` (geomap, prod/dev `.web.app`, localhost);
+  otherwise it falls back to the prod referer (so secured layers don't load).
+  Per-PR preview channels have unique URLs not in that list.
+- Existing CI `firebase-hosting-pull-request.yml` already auto-deploys a **unique
+  dev preview channel per PR** via `FirebaseExtended/action-hosting-deploy`,
+  which exposes the channel URL as the step output `details_url`.
+- `firebase-admin` is already initialized in the function (`admin.initializeApp()`).
+  Firestore is **not yet** configured in the repo (`firebase.json` has only
+  `functions` + `hosting`).
+- A manual `readout-panel` channel is currently hard-coded in the *deployed* prod
+  function as a stopgap; this design **retires** it.
+
+## Design
+
+### Store
+A Firestore collection **`previewReferers`** in the **prod** project (where the
+function runs), one document per open PR:
+- doc id = PR number (e.g. `147`)
+- fields: `{ url: <channel origin>, pr: <number>, updatedAt: <timestamp> }`
+
+Doc-per-PR (vs a single array) so concurrent PRs don't contend, and **close
+deletes by PR number** without needing to know the channel URL.
+
+### Security rules
+Add `firestore.rules` (and the `firestore` block in `firebase.json`) that
+**deny all client reads/writes** (default-deny; `previewReferers` included). The
+collection is read only by the function's runtime service account (server-side
+Admin SDK, which bypasses rules) and written only by CI's prod service account.
+No browser ever reads or writes it.
+
+### Function (`getArcGISToken`)
+- Static `ALLOWED_REFERERS` stays: `geomap.geology.utah.gov`,
+  `…-(prod|dev).web.app`, `localhost`/`127.0.0.1`. **Remove** the `readout-panel`
+  hard-code.
+- Determine the bound referer:
+  1. If the caller origin matches a static entry → bind to it (unchanged).
+  2. Else read `previewReferers` docs, collect their `url`s; if the caller origin
+     **exactly** matches one → bind to it.
+  3. Else → fall back to the prod referer (no secured layers), as today.
+- The function's existing `cors` allowlist already lets `…-dev--<channel>.web.app`
+  origins call it — keep it.
+- The Firestore read happens per token-mint, which is low-frequency (once per page
+  session, after anonymous auth). An in-memory cache is a later optimization, not
+  required.
+
+### CI — add on PR open/update
+Extend `firebase-hosting-pull-request.yml`:
+- Give the deploy step an `id`.
+- Add a step that writes `previewReferers/{PR_NUMBER} = { url: <details_url>, pr }`
+  to **prod** Firestore, authenticated with the **prod** service account secret
+  (`FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_PROD`). (The deploy step
+  itself keeps using the dev SA; the Firestore write is a separate step with the
+  prod SA.) The write uses a small `firebase-admin` Node script.
+
+### CI — remove on PR close
+New workflow on `pull_request: [closed]`:
+- Delete `previewReferers/{PR_NUMBER}` from prod Firestore (prod SA). Keyed by PR
+  number, so no channel URL is needed at close time.
+- Optionally also delete the dev channel for tidiness.
+
+## Security properties
+
+At any moment, a valid origin-bound token (the thing that unlocks secured layers)
+is grantable only to: the static origins (prod / dev / localhost) **plus** the
+exact URLs of currently-open PRs' channels. Never a wildcard/pattern. The dynamic
+entries are written only by CI (prod SA), only ever contain channels CI deployed
+for a real PR in this repo, are denied to all clients, and are removed on PR
+close. A stale entry (if cleanup ever lagged) points at an expired/dead channel
+that 404s — no data exposure.
+
+## Transition / sequencing
+
+Deploying the dynamic function to prod removes the `readout-panel` hard-code, so
+the manual `readout-panel` channel stops loading secured layers. To keep part-1
+review going, either (recommended) open a PR for the redesign branch — its
+auto preview channel becomes dynamically allowlisted and is the new review
+surface — or temporarily keep a static `readout-panel` entry until then.
+
+## Testing (manual + a rules check)
+
+- Open a throwaway PR → CI deploys the preview channel and writes the Firestore
+  entry → open the preview URL → secured geology renders.
+- Close the PR → CI deletes the entry → re-open the (now dead/!allowlisted) URL →
+  no secured layers.
+- Verify `firestore.rules` deny client access (emulator/rules test or console).
+- Static origins (prod/dev site, localhost) still load secured layers; a
+  random non-allowlisted origin does not.
+- `node --check` on any changed JS; CI YAML validated by a dry run / lint.
+
+## Out of scope
+
+- The same-origin proxy (the long-term, origin-independent fix — belongs with the
+  MapLibre/TanStack rewrite).
+- The readout redesign (parts 1 & 2).
+- Caching the Firestore read.
+
+## Risks / notes
+
+- Mixed credentials in the PR workflow (dev SA to deploy, prod SA to write prod
+  Firestore) — keep them in separate steps with separate secrets.
+- Enabling Firestore + the prod function deploy + the new CI are prod/infra
+  changes; the user runs/approves those deploys (and enables Firestore once).
+- The prod function's runtime SA needs Firestore read (Firebase default SA has
+  it); CI's prod SA needs Firestore write (the deploy SA typically does).

--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,10 @@
       ]
     }
   ],
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
   "hosting": {
     "public": "public",
     "ignore": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Deny all client (browser) access. `previewReferers` is written only by CI (a service
+    // account, via the Admin SDK) and read only by Cloud Functions (Admin SDK) -- both bypass
+    // these rules. No browser should ever read or write Firestore in this project.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -132,6 +132,22 @@ exports.getData = functions.https.onRequest((req, res) => {
 });
 
 
+// Open-PR preview channels are allowlisted dynamically: CI maintains one doc per open PR in
+// the `previewReferers` collection (id = PR number, field `url` = the channel origin), adding
+// on PR open and removing on PR close. Returns true if `origin` exactly matches a current entry.
+async function isAllowedPreviewReferer(origin) {
+  try {
+    const norm = origin.replace(/\/+$/, '');
+    const snap = await admin.firestore().collection('previewReferers').get();
+    return snap.docs.some(function (doc) {
+      return (doc.get('url') || '').replace(/\/+$/, '') === norm;
+    });
+  } catch (err) {
+    logger.error('previewReferers lookup failed:', err);
+    return false;  // fail closed: an unverified origin gets no secured token
+  }
+}
+
 exports.getArcGISToken = onCall({
   region: "us-central1",
   maxInstances: 10,
@@ -150,12 +166,11 @@ exports.getArcGISToken = onCall({
 }, async (request) => {
   try {
     // Mint the token with a referer matching the *validated* calling origin. ArcGIS referer
-    // tokens are checked against each request's Referer header, so for the secured services to
-    // load from anywhere other than geomap (localhost, the dev channel, prod .web.app), the
-    // token's referer must equal that page's origin. Only origins on this allowlist are honored;
-    // anything else (including unknown/forged Origin headers) falls back to prod. NOTE: ephemeral
-    // PR-preview channels are intentionally excluded — their URLs are semi-public, and a
-    // preview-referer token would let anyone with the link read the unpublished data.
+    // tokens are checked against each request's Referer header, so the token's referer must equal
+    // the page's origin. Static origins (geomap, prod/dev sites, localhost) are always honored.
+    // Open-PR preview channels are honored dynamically via the `previewReferers` collection (CI
+    // adds each open PR's channel URL and removes it on close), so only currently-open previews
+    // qualify. Anything else falls back to prod (no secured layers).
     const ALLOWED_REFERERS = [
       /^https:\/\/geomap\.geology\.utah\.gov$/,
       /^https:\/\/ut-dnr-ugs-geolmapportal-(prod|dev)\.web\.app$/,
@@ -163,9 +178,9 @@ exports.getArcGISToken = onCall({
       /^http:\/\/127\.0\.0\.1(:\d+)?$/
     ];
     const callerOrigin = ((request.rawRequest && request.rawRequest.headers && request.rawRequest.headers.origin) || '').trim();
-    const referer = ALLOWED_REFERERS.some(function (re) { return re.test(callerOrigin); })
-      ? callerOrigin
-      : 'https://geomap.geology.utah.gov';
+    const isStatic = ALLOWED_REFERERS.some(function (re) { return re.test(callerOrigin); });
+    const isOpenPreview = (!isStatic && callerOrigin) ? await isAllowedPreviewReferer(callerOrigin) : false;
+    const referer = (isStatic || isOpenPreview) ? callerOrigin : 'https://geomap.geology.utah.gov';
 
     // Get credentials from Secret Manager
     const [usernameVersion] = await secretClient.accessSecretVersion({


### PR DESCRIPTION
## Summary
Open-PR dev preview channels can now load the secured ArcGIS layers automatically, with the referer allowlist staying tight and self-cleaning.

`getArcGISToken` reads a locked-down `previewReferers` Firestore collection (one doc per open PR) in addition to the static origins (geomap, prod/dev sites, localhost). CI writes each PR's channel URL on open (`firebase-hosting-pull-request.yml`) and removes it on close (`preview-referer-cleanup.yml`), so only currently-open previews qualify. `firestore.rules` deny all client access; the read fails closed. Retires the manual `readout-panel` hard-code.

Spec: `docs/specs/2026-06-06-dynamic-preview-allowlist-design.md`

## What changed
- `functions/index.js` — dynamic referer check (Firestore) + helper
- `firestore.rules` + `firestore` block in `firebase.json` (deny-all)
- `firebase-hosting-pull-request.yml` — add step to allowlist the PR's channel
- `preview-referer-cleanup.yml` (new) — remove on PR close
- `.github/scripts/preview-referer.js` — admin helper

## Activation (post-merge, prod)
Firestore is already enabled in prod (Native, us-central1). The prod function + rules still need deploying — handled by the upcoming functions-deploy CI (separate PR), or a one-off deploy. The client doesn't use Firestore, so the deny-all rules are safe.

## Notes
- `node --check` + workflow YAML parse pass. First real test is the next PR's preview channel.