### PR TITLE
ci: deploy functions and firestore rules to prod on merge

### DIFF
--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -3,8 +3,9 @@ name: Deploy Functions and Firestore rules to prod
 # getArcGISToken (gen2 callable) and getData (gen1) live in the PROD project; the browser always
 # calls the prod function, even from dev and preview-channel hosting. firebase-hosting-merge.yml
 # deploys hosting only -- the FirebaseExtended action can't deploy functions -- so this workflow
-# covers the rest: Cloud Functions plus Firestore rules/indexes (the deny-all rules that protect
-# the previewReferers collection getArcGISToken reads).
+# covers the rest: Cloud Functions plus the deny-all Firestore rules that protect the
+# previewReferers collection getArcGISToken reads. (firestore.indexes.json is empty, so indexes are
+# intentionally not deployed here -- which also keeps datastore.indexAdmin off the deploy SA.)
 #
 # Runs on master pushes that touch the relevant paths, and on manual dispatch (use dispatch from
 # the `dev` branch for the first prod rollout / to validate the deploy service account's roles).
@@ -16,7 +17,6 @@ on:
       - 'functions/**'
       - 'firebase.json'
       - 'firestore.rules'
-      - 'firestore.indexes.json'
       - '.github/workflows/firebase-functions-deploy.yml'
   workflow_dispatch: {}
 
@@ -53,6 +53,6 @@ jobs:
           # firebase-tools is pinned to an exact version for reproducible deploys. It is invoked via
           # npx (not a functions dependency), so Dependabot does not track it -- bump deliberately.
           npx --yes firebase-tools@15.19.1 deploy \
-            --only functions,firestore \
+            --only functions,firestore:rules \
             --project ut-dnr-ugs-geolmapportal-prod \
             --non-interactive

--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -7,8 +7,10 @@ name: Deploy Functions and Firestore rules to prod
 # previewReferers collection getArcGISToken reads. (firestore.indexes.json is empty, so indexes are
 # intentionally not deployed here -- which also keeps datastore.indexAdmin off the deploy SA.)
 #
-# Runs on master pushes that touch the relevant paths, and on manual dispatch (use dispatch from
-# the `dev` branch for the first prod rollout / to validate the deploy service account's roles).
+# Runs on master pushes that touch the relevant paths. workflow_dispatch is also enabled for manual
+# re-deploys (e.g. re-running a deploy after an IAM fix without a new commit), but GitHub only
+# exposes that trigger once this file is on the default branch (master) -- so the first prod deploy
+# happens automatically on the first dev->master promotion, not via a pre-merge dispatch.
 on:
   push:
     branches:

--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy Functions and Firestore rules to prod
+
+# getArcGISToken (gen2 callable) and getData (gen1) live in the PROD project; the browser always
+# calls the prod function, even from dev and preview-channel hosting. firebase-hosting-merge.yml
+# deploys hosting only -- the FirebaseExtended action can't deploy functions -- so this workflow
+# covers the rest: Cloud Functions plus Firestore rules/indexes (the deny-all rules that protect
+# the previewReferers collection getArcGISToken reads).
+#
+# Runs on master pushes that touch the relevant paths, and on manual dispatch (use dispatch from
+# the `dev` branch for the first prod rollout / to validate the deploy service account's roles).
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'functions/**'
+      - 'firebase.json'
+      - 'firestore.rules'
+      - 'firestore.indexes.json'
+      - '.github/workflows/firebase-functions-deploy.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Never run two prod deploys at once; queue rather than cancel so an in-flight deploy completes.
+concurrency:
+  group: deploy-functions-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install function dependencies
+        working-directory: functions
+        run: npm ci
+
+      - name: Deploy functions and Firestore rules to prod
+        env:
+          PROD_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_PROD }}
+        run: |
+          printf '%s' "$PROD_SA" > "$RUNNER_TEMP/prod-sa.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/prod-sa.json"
+          # firebase-tools is pinned to an exact version for reproducible deploys. It is invoked via
+          # npx (not a functions dependency), so Dependabot does not track it -- bump deliberately.
+          npx --yes firebase-tools@15.19.1 deploy \
+            --only functions,firestore \
+            --project ut-dnr-ugs-geolmapportal-prod \
+            --non-interactive

--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,7 @@
     {
       "source": "functions",
       "codebase": "default",
-      "runtime": "nodejs20",
+      "runtime": "nodejs22",
       "ignore": [
         "node_modules",
         ".git",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -16,7 +16,7 @@
         "firebase-functions-test": "^3.1.0"
       },
       "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.0.0",
         "npm": ">=10.0.0"
       }
     },

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=10.0.0"
   },
   "main": "index.js",


### PR DESCRIPTION
## Summary
- **New CI workflow** (`firebase-functions-deploy.yml`): deploys Cloud Functions + Firestore **rules** to the **prod** project on `master` pushes (path-filtered) and on manual `workflow_dispatch`. Functions were previously deployed by hand.
- **Runtime bump** `nodejs20` → `nodejs22` (firebase.json + functions engines + lockfile), off maintenance-track Node 20.

## Why
The existing `firebase-hosting-merge.yml` deploys **hosting only** — the FirebaseExtended action can't deploy functions. So the dynamic-allowlist `getArcGISToken` (the `previewReferers` Firestore read from #147) and the new deny-all `firestore.rules` have no automated path to prod. This workflow closes that gap and gets functions onto CI.

`getData` is gen1 and `getArcGISToken` is gen2; nodejs22 is supported for **both** generations per Google's runtime-support matrix, so the single codebase-wide `runtime` field carries both. Firestore deploy is scoped to `firestore:rules` (indexes.json is empty) to keep `datastore.indexAdmin` off the deploy SA.

## Review
- **Code-review agent** (CI/Firebase focus) ran on the diff. It raised a "blocker" claiming nodejs22 is gen1-incompatible — **verified false** against Google's current runtime-support docs (the cited GitHub issues were stale; nodejs22 is listed as "1st gen, Run functions"). Its valid findings were addressed: lockfile engines synced, firebase-tools pinned to an exact version. Secret handling (temp file, no echo, least-privilege `permissions:`) confirmed clean.

## Prerequisite before first prod deploy (prod IAM)
The deploy SA (`github-action-257701712@…-prod`) has Hosting Admin + Datastore User only. Deploying functions+rules needs additional roles: cloudfunctions.developer, cloudbuild.builds.editor, artifactregistry.admin, run.developer, iam.serviceAccountUser, firebaserules.admin. Grant these before promoting to master.

`workflow_dispatch` is only exposed once this workflow reaches the default branch (master), so the first prod deploy runs automatically on the first `dev`→`master` promotion (not a pre-merge dispatch).

## Test plan
- [ ] Grant deploy SA the functions/rules roles
- [ ] First `dev`→`master` promotion → functions-deploy workflow runs → dynamic-read `getArcGISToken` + deny-all rules live on prod
- [ ] Open a throwaway PR into dev → preview channel loads secured geology layers
- [ ] Close the PR → allowlist entry removed, secured layers no longer load on that channel