### PR TITLE
fix(ci): scope prod deploy to named functions

### DIFF
--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -54,7 +54,12 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/prod-sa.json"
           # firebase-tools is pinned to an exact version for reproducible deploys. It is invoked via
           # npx (not a functions dependency), so Dependabot does not track it -- bump deliberately.
+          #
+          # Deploy this repo's functions BY NAME. getArcGISTokenHttp also lives in this prod
+          # project's `default` codebase (consumed cross-app by boreholeApp's proxyGetArcGISToken
+          # over authenticated OIDC) but is intentionally not in this repo's source. A whole-codebase
+          # `--only functions` deploy would propose deleting it; naming targets prevents that.
           npx --yes firebase-tools@15.19.1 deploy \
-            --only functions,firestore:rules \
+            --only functions:getData,functions:getArcGISToken,firestore:rules \
             --project ut-dnr-ugs-geolmapportal-prod \
             --non-interactive


### PR DESCRIPTION
## Summary
Scope the prod functions deploy to **named targets** — `--only functions:getData,functions:getArcGISToken,firestore:rules` — instead of the whole `functions` codebase.

## Why (real prod risk found during the first manual deploy)
`getArcGISTokenHttp` also lives in this prod project's `default` codebase but is **not in this repo's source**. It's a live, IAM-secured cross-app dependency: `boreholeApp/functions/index.js` (`proxyGetArcGISToken`) calls it server-to-server over authenticated OIDC.

A whole-codebase `--only functions` deploy detects it as "not in local source" and proposes deleting it (the manual deploy hit exactly this prompt; answering **N** preserved it). `--non-interactive` skips the deletion today, but that's fragile — a single `--force` would delete it and break boreholeApp's ArcGIS token retrieval. Naming targets makes deletion impossible from this workflow.

## Follow-up (not in this PR)
`getArcGISTokenHttp` is unmanaged-in-source. Bringing it under version control (here or in a shared functions repo) is worth a deliberate pass — needs its current implementation and an owner decision.

## Review
Trivial scoping change (deploy target list + comment), self-reviewed. This PR's own lifecycle doubles as the dynamic-allowlist validation: opening it allowlists its preview channel; merging it triggers the cleanup workflow.