### PR TITLE
ci: align dev workflows to actions/checkout@v6 (Node 24)

### DIFF
--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -31,7 +31,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/firebase-functions-deploy.yml
+++ b/.github/workflows/firebase-functions-deploy.yml
@@ -31,7 +31,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -18,7 +18,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -18,7 +18,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'dev' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set Firebase config
         run: |
           echo "FIREBASE_SERVICE_ACCOUNT=FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_DEV" >> $GITHUB_ENV

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'dev' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set Firebase config
         run: |
           echo "FIREBASE_SERVICE_ACCOUNT=FIREBASE_SERVICE_ACCOUNT_UT_DNR_UGS_GEOLMAPPORTAL_DEV" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
Bump `actions/checkout@v4` → `@v6` in dev's four workflows.

## Why
`master` already runs `actions/checkout@v6` (dependabot bumped it there); only `dev` lagged at `@v4`. v6 runs on **Node 24**, so this:
- makes dev/PR CI Node-24-safe ahead of GitHub's 2026-06-16 forced migration, and
- removes the version drift, so a future `dev→master` promotion won't downgrade checkout.

`FirebaseExtended/action-hosting-deploy` stays `@v0` (its latest *release* is still Node 20; `@v0` will auto-adopt a Node 24 release when published — same as master).

## Prod note
Prod (master) is already on checkout@v6, so **nothing here needs pushing to prod** — this only brings dev in line. This PR's own build exercises checkout@v6.