### PR TITLE
feat(readout): Refined Light visual redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ node_modules/
 .DS_Store
 
 .php
+# superpowers brainstorm companion mockups
+.superpowers/

--- a/docs/plans/2026-06-06-consolidated-readout-panel.md
+++ b/docs/plans/2026-06-06-consolidated-readout-panel.md
@@ -1,0 +1,447 @@
+# Consolidated Feature Readout Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold the Map Downloads card's downloads, citation, and per-map actions into the click readout, with a responsive two-column (desktop) / stacked-with-disclosure (mobile) layout and a single scroll container — vanilla, no new libraries.
+
+**Architecture:** All changes live in `public/mapcontrols.js` + `public/style.css` (the repo's single-file pattern). Add shared helpers (`buildCitation`, `buildPubLink`), a `renderResources()` block injected into each readout section, event-delegated tool handlers, responsive CSS at a 768px breakpoint, and a single-scroll panel with a pinned header (achieved by making `#udTab` the scroller and switching `#unitsPane` show/hide to class-based so a CSS flex layout holds).
+
+**Tech Stack:** Vanilla JS (ArcGIS Maps SDK + jQuery) + CSS; Firebase `getData` + pg_featureserv. No build step.
+
+**Testing note:** This repo has no frontend test runner (`npm test` is a no-op). The readout panel is fully testable on `http://localhost:5000` via `npx firebase serve --only hosting` — the footprints layer (AGOL), pg_featureserv, and `getData` are all public, so clicking the map and exercising the panel works locally. Only the *secured ArcGIS base geology tiles* won't render locally; that does not block testing the panel's content/layout. After every code change run `node --check public/mapcontrols.js`; after CSS changes confirm braces balance (`[ "$(tr -cd '{' < public/style.css | wc -c)" = "$(tr -cd '}' < public/style.css | wc -c)" ]`). Full base-tile fidelity is verified on the dev site after merge.
+
+Spec: `docs/specs/2026-06-06-consolidated-readout-panel-design.md`.
+
+---
+
+## File structure
+
+- **Modify** `public/mapcontrols.js` — `buildCitation`/`buildPubLink` helpers; `renderResources`/`fillResources`; restructure `loadUnitDescription` + `loadPublicationOnly` section bodies; delegated tool/copy/xsection/disclosure handlers; widen `prefetchPubData`; class-based `#unitsPane` show/hide.
+- **Modify** `public/style.css` — responsive section grid, resources rail, disclosure groups, download/tool/citation styling (reusing the existing `pdfIcon`/`gisIcon`/`tiffIcon`/`xsecIcon`/`purIcon` glyphs), mobile description truncation, single-scroll panel sizing + bottom sheet, pinned-header flex layout.
+
+No new files (single-file pattern). No `package.json` changes (no new dependency).
+
+Out of scope (separate follow-ups): removing the Map Downloads mode/swiper (`#identifyPanel`, `toggleMapDl`, `#mapsPane`, `printPubs`); the layer-list / scale-button reorg.
+
+---
+
+### Task 1: Shared helpers — `buildCitation` + `buildPubLink`
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add the two helpers** immediately after the `displaySeriesId` function.
+
+```js
+// citation string for a publication record (shared by the readout + the downloads carousel).
+// pub_sec_author is free text that may already contain "and" + multiple names (e.g.
+// "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't already have one.
+function buildCitation(rec) {
+    if (!rec) return '';
+    var authors = rec.pub_author || '';
+    if (rec.pub_sec_author) {
+        var sec = String(rec.pub_sec_author).trim();
+        if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
+    }
+    var scaleInt = scaleToInt(rec.pub_scale);
+    var publisher = rec.pub_publisher ? rec.pub_publisher : '';
+    return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + '. 1:' + scaleInt + ',000 scale.';
+}
+
+// publisher-aware publication link: UGS/UGMS -> our DOI; other publishers -> the UGS catalog
+// page (we host the page but not their DOI, so it must not be labeled a DOI link).
+function buildPubLink(seriesId, rec) {
+    var pub = (rec && rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
+    var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
+    return isUgs
+        ? '<a target="_blank" href="https://doi.org/10.34191/' + seriesId + '">DOI Link</a>'
+        : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + seriesId + '">Publication Page</a>';
+}
+```
+
+- [ ] **Step 2: Use `buildCitation` in `printPubs`.** Find the citation block in `printPubs` (the `var authors = arr.pub_author; if (arr.pub_sec_author) {…} var reftxt = authors + ', ' + arr.pub_year + …;`) and replace the whole `authors`/`reftxt` computation with:
+
+```js
+        var reftxt = buildCitation(arr);
+```
+
+(`publisher`/`scaleInt` locals above it stay; only the author-join + `reftxt` lines collapse into the helper call.)
+
+- [ ] **Step 3: Syntax check.** Run: `node --check public/mapcontrols.js` — expect no output (exit 0).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "refactor(readout): extract buildCitation + buildPubLink helpers"
+```
+
+---
+
+### Task 2: getData returns the full record + prefetch all footprints
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Return the full publication record from `getPubData`.** Today it strips the result to `{ pub_url, geotiff, pub_publisher }`, but the resources block needs `gis_data`, `x_section`, `bsurl`, and the citation fields. In `getPubData`, replace the `.then(function (data) { var rec = …; return rec ? { pub_url:…, geotiff:…, pub_publisher:… } : null; })` with:
+
+```js
+        .then(function (data) { return (data && data[0]) ? data[0] : null; });
+```
+
+(The full record is a superset of the old shape, so the existing `pub_url`/`geotiff`/`pub_publisher` reads still work. `getPubData` remains memoized by `series_id`.)
+
+- [ ] **Step 2: Widen `prefetchPubData`.** Replace the function body (currently filters `a.units !== 'True'`) with:
+
+```js
+function prefetchPubData(ftrs) {
+    for (var i = 0; i < ftrs.length; i++) {
+        var sid = ftrs[i].attributes.series_id;
+        if (sid) getPubData(sid).catch(function () {});
+    }
+}
+```
+
+(Every section now shows downloads/citation, so warm the cache for all maps at the point.)
+
+- [ ] **Step 3: Syntax check.** Run: `node --check public/mapcontrols.js` — exit 0.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "perf(readout): return full pub record + prefetch all footprints at the point"
+```
+
+---
+
+### Task 3: Resources renderer + wire into both section paths
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add `renderResources` + `fillResources`** immediately after `buildPubLink`.
+
+```js
+// the resources block (publication link, downloads, citation, map tools) for one section.
+// rec is the getData record (may be null while loading / if the map has no record).
+function renderResources(rec, atts) {
+    var sid = atts.series_id;
+    var pubLink = '<div class="res-publink">' + buildPubLink(sid, rec) + '</div>';
+
+    var dl = [];
+    if (rec && rec.pub_url)   dl.push('<a class="downloadList pdfIcon"  target="_blank" href="' + rec.pub_url + '">PDF</a>');
+    if (rec && rec.gis_data)  dl.push('<a class="downloadList gisIcon"  target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.gis_data + '">GIS data</a>');
+    if (rec && rec.geotiff)   dl.push('<a class="downloadList tiffIcon" target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
+    if (rec && rec.x_section) dl.push('<a class="downloadList xsecIcon res-xsec" href="#" data-xsec="' + rec.x_section + '">Cross-section</a>');
+    if (rec && rec.bsurl)     dl.push('<a class="downloadList purIcon" target="_blank" href="https://utahmapstore.com/products/' + sid + '">Purchase</a>');
+    var downloads = dl.length
+        ? '<div class="res-downloads">' + dl.join('') + '</div>'
+        : '<div class="res-empty">No downloads available for this map.</div>';
+
+    var citeText = rec ? buildCitation(rec) : '';
+    var cite = citeText
+        ? '<div class="res-cite"><span class="res-cite-text">' + citeText + '</span>' +
+          '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
+        : '';
+
+    var tools = '<div class="res-tools">' +
+        '<button type="button" class="res-tool res-pan"   title="Pan to this map">Pan to</button>' +
+        '<button type="button" class="res-tool res-zoom"  title="Zoom to this map">Zoom to</button>' +
+        '<button type="button" class="res-tool res-share" title="Copy a shareable link">Copy link</button>' +
+        '</div>';
+
+    var dlOpen = (atts.units === 'True') ? '' : ' open';   // pub-only maps lead with downloads
+    return pubLink +
+        '<div class="readout-group readout-group-dl' + dlOpen + '">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="' + (dlOpen ? 'true' : 'false') + '">Downloads &amp; citation</button>' +
+            '<div class="readout-group-content">' + downloads + cite + '</div>' +
+        '</div>' +
+        '<div class="readout-group readout-group-tools">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="false">Map tools</button>' +
+            '<div class="readout-group-content">' + tools + '</div>' +
+        '</div>';
+}
+
+// fill a section's .readout-resources once the (prefetched) getData record resolves
+function fillResources(atts, container) {
+    if (!container) return;
+    getPubData(atts.series_id)
+        .then(function (rec) { if (container.isConnected) container.innerHTML = renderResources(rec, atts); })
+        .catch(function () { if (container.isConnected) container.innerHTML = renderResources(null, atts); });
+}
+```
+
+- [ ] **Step 2: Restructure the `units==='True'` render in `loadUnitDescription`.** Replace the `bodyEl.innerHTML = …` assignment (identity + description + the old `.unit-desc-ref` DOI line) with the section-body wrapper + a resources placeholder, then call `fillResources`:
+
+```js
+        bodyEl.innerHTML =
+            '<div class="readout-section-body">' +
+                '<div class="readout-main">' +
+                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
+                    '<div class="unit-desc-text">' + desc + '</div>' +
+                    '<button type="button" class="readout-show-more">Show more</button>' +
+                '</div>' +
+                '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+            '</div>';
+        fillResources(atts, bodyEl.querySelector('.readout-resources'));
+```
+
+(The old `<div class="unit-desc-ref">…DOI Link…</div>` line is removed — the publication link now lives in the resources block.)
+
+- [ ] **Step 3: Replace `loadPublicationOnly` entirely** with the unified version (its old `paint`/`getPubData` body is superseded by `fillResources`/`renderResources`):
+
+```js
+// load a units=False map's publication-only section (no unit description)
+function loadPublicationOnly(atts, bodyEl) {
+    bodyEl.innerHTML =
+        '<div class="readout-section-body readout-pubonly">' +
+            '<div class="readout-main"><div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div></div>' +
+            '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+        '</div>';
+    fillResources(atts, bodyEl.querySelector('.readout-resources'));
+}
+```
+
+- [ ] **Step 4: Syntax check.** Run: `node --check public/mapcontrols.js` — exit 0.
+
+- [ ] **Step 5: Manual check.** Run `npx firebase serve --only hosting`; in the browser, enable the unit-descriptions pane and click a detailed map (e.g. Duchesne `M-300DM`) and the Utah State 250k (`Q-2thru5`). Expected: each open section shows the publication link plus "Downloads & citation" and "Map tools" groups (unstyled until Task 5); `Q-2thru5` shows PDF/GeoTIFF + the multi-author citation; a USGS quad (`I-2462`) shows "Publication Page".
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "feat(readout): render downloads, citation, and map tools in each section"
+```
+
+---
+
+### Task 4: Section tool handlers (pan/zoom/share, copy, cross-section)
+
+**Files:** Modify `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add delegated handlers** next to the other `$(document).on(...)` / jQuery click handlers (sections are rebuilt on every click, so delegation is required).
+
+```js
+// resources: copy citation
+$(document).on('click', '#udTab .res-copy', function (e) {
+    e.preventDefault();
+    copyToClipboard(decodeURIComponent(this.getAttribute('data-cite') || ''));
+});
+// resources: open the cross-section in the existing image viewer
+$(document).on('click', '#udTab .res-xsec', function (e) {
+    e.preventDefault();
+    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('#xsection-pane').removeClass('hidden');
+});
+// resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx
+$(document).on('click', '#udTab .res-tool', function (e) {
+    e.preventDefault();
+    var host = this.closest('[data-idx]');
+    if (!host) return;
+    var ftr = accordionFtrs[parseInt(host.getAttribute('data-idx'), 10)];
+    if (!ftr || !ftr.geometry) return;
+    var ext = ftr.geometry.extent;
+    if (this.classList.contains('res-pan') && ext) {
+        view.center = ext.center;
+    } else if (this.classList.contains('res-zoom') && ext) {
+        view.extent = ext;
+        view.zoom = view.zoom - 1;
+    } else if (this.classList.contains('res-share')) {
+        var sid = ftr.attributes.series_id;
+        var sc = parseInt(ftr.attributes.scale);
+        var lyrs = (sc <= 24) ? '24k' : (sc < 250) ? '100k' : '500k';
+        var base = window.location.href.split('#')[0].split('?')[0];
+        copyToClipboard(encodeURI(base + '?view=scene&sid=' + sid + '&layers=' + lyrs));
+    }
+});
+```
+
+- [ ] **Step 2: Syntax check.** Run: `node --check public/mapcontrols.js` — exit 0.
+
+- [ ] **Step 3: Manual check.** Reload local; open a section. Expected: "Copy link" / "Pan to" / "Zoom to" act on that map's footprint; the citation copy button copies the reference; "Cross-section" (on a map that has one) opens the `#xsection-pane` image.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add public/mapcontrols.js
+git commit -m "feat(readout): wire section pan/zoom/share, citation copy, and cross-section viewer"
+```
+
+---
+
+### Task 5: Responsive layout, disclosure groups, icon reuse, mobile truncation
+
+**Files:** Modify `public/style.css`, `public/mapcontrols.js`.
+
+- [ ] **Step 1: Add the resources/section CSS** (append within the readout CSS region of `public/style.css`).
+
+```css
+/* consolidated section: stacked by default; two columns on desktop (Task assigns the media query) */
+.readout-section-body { display: block; }
+.readout-main, .readout-resources { min-width: 0; }
+
+.res-publink { font-size: 11px; margin: 4px 0; }
+.res-downloads { display: flex; flex-direction: column; gap: 3px; margin: 4px 0; }
+.res-downloads .downloadList { font-size: 12px; line-height: 18px; }
+.res-empty { font-size: 11px; color: #9a9a9a; margin: 4px 0; }
+
+.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 10px; line-height: 13px; color: #555; }
+.res-cite-text { flex: 1; }
+.res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
+
+.res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.res-tool { font-size: 11px; padding: 3px 8px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
+.res-tool:hover { background: #eceff4; }
+
+/* disclosure groups: collapsible on mobile, always-open rail on desktop */
+.readout-group { margin-top: 8px; }
+.readout-group-toggle { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; border: none; background: none; padding: 4px 0; cursor: pointer; font: 600 12px "Avenir Next W00", Helvetica, Arial, sans-serif; color: #4a4a4a; }
+.readout-group-toggle::before { content: "\25B8"; font-size: 9px; transition: transform .15s ease; }
+.readout-group.open .readout-group-toggle::before { transform: rotate(90deg); }
+.readout-group-content { display: none; padding-left: 2px; }
+.readout-group.open .readout-group-content { display: block; }
+
+.readout-show-more { display: none; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
+
+@media (min-width: 768px) {
+    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(165px, 1fr); gap: 12px; }
+    .readout-pubonly .readout-section-body { grid-template-columns: 1fr; }
+    .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
+    .readout-group-content { display: block; }
+    .readout-group { margin-top: 10px; }
+}
+
+@media (max-width: 767px) {
+    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
+    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
+    .readout-show-more { display: inline-block; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .readout-group-toggle::before { transition: none; }
+}
+```
+
+- [ ] **Step 2: Add the disclosure + show-more handlers** in `public/mapcontrols.js` (next to the Task 4 handlers).
+
+```js
+// resources: toggle a disclosure group (mobile); description show more/less (mobile)
+$(document).on('click', '#udTab .readout-group-toggle', function () {
+    var open = this.parentNode.classList.toggle('open');
+    this.setAttribute('aria-expanded', open ? 'true' : 'false');
+});
+$(document).on('click', '#udTab .readout-show-more', function () {
+    var main = this.closest('.readout-main');
+    if (!main) return;
+    this.textContent = main.classList.toggle('expanded') ? 'Show less' : 'Show more';
+});
+```
+
+- [ ] **Step 3: Checks.** Run `node --check public/mapcontrols.js` (exit 0) and confirm `style.css` braces balance.
+
+- [ ] **Step 4: Manual check.** Local browser. Desktop window (>768px): open section shows description left, resources rail right (groups expanded, no toggles). Narrow the window (<768px): layout stacks, groups collapse with ▸ toggles, description clamps to 5 lines with "Show more".
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/style.css public/mapcontrols.js
+git commit -m "feat(readout): responsive 2-col/stacked layout, disclosure groups, mobile truncation"
+```
+
+---
+
+### Task 6: Single-scroll panel + widen desktop / bottom sheet mobile
+
+**Files:** Modify `public/style.css`.
+
+- [ ] **Step 1: Revert the pinned-flex readout rules to plain flow** so there is one scroll container. In `public/style.css`, change:
+
+```css
+.map-readout { display: flex; flex-direction: column; max-height: calc(75vh - 30px); font-size: 13px; }
+```
+to:
+```css
+.map-readout { font-size: 13px; }
+```
+Change `.readout-primary { flex: 0 1 auto; min-height: 0; display: flex; flex-direction: column; padding: 0 2px; }` to `.readout-primary { padding: 0 2px; }`. Change `.readout-others { … }` to drop `flex`, `min-height`, `display:flex`, `overflow-y`, `overscroll-behavior` (keep its `border-top`/`margin-top`/`padding-top`). **Delete** the rules `.readout-primary .map-section-readout { … max-height: 45vh … }` and `.map-section.open .map-section-readout { max-height: 30vh … }`. Drop `flex: none;` from `.map-section` and `.other-maps-label`.
+
+(Progressive disclosure now keeps sections compact, so a single panel scrollbar is correct and the nested `vh` caps that caused the multi-scrollbar confusion are gone.)
+
+- [ ] **Step 2: Widen the desktop panel + add the mobile bottom sheet.** Change `#unitsPane`'s `width: 300px;` to `width: 440px;` and its `opacity: 0.85;` to `opacity: 0.96;` (leave `max-height`, `position`, `bottom`, `right`, `padding` as set in PR #144). Add, after the `#unitsPane` rule:
+
+```css
+@media (max-width: 767px) {
+    #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }
+}
+```
+
+- [ ] **Step 3: Confirm braces balance** in `style.css`.
+
+- [ ] **Step 4: Manual check.** Local browser. Desktop: panel is ~440px, one scrollbar, text crisp. Zoom Chrome to ~150–175% with a long description + an open "other map": nothing clipped, single scrollbar. Narrow window: panel spans full width, bottom-anchored.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/style.css
+git commit -m "feat(readout): single-scroll panel, 440px desktop / full-width bottom sheet on mobile"
+```
+
+---
+
+### Task 7: Pin the panel header/close (flex panel + class-based show/hide)
+
+**Files:** Modify `public/style.css`, `public/mapcontrols.js`.
+
+- [ ] **Step 1: Make `#udTab` the scroll container and `#unitsPane` a non-scrolling flex column.** In `public/style.css`, change `#unitsPane`'s `overflow-y: auto;` to `overflow: hidden;` and add `display: flex; flex-direction: column;`. Add these rules after it:
+
+```css
+/* #udTab is the single scroller; the close button (absolute in #unitsPane) stays pinned */
+#udTab { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+#unitsPane.hidden { display: none; }   /* beat the id-specificity of display:flex when hidden */
+```
+
+- [ ] **Step 2: Switch `#unitsPane` show/hide to class-based** so jQuery's `.show()` can't inject `display:block` over the flex layout. In `public/mapcontrols.js` replace every `$("#unitsPane").show()` with `$("#unitsPane").removeClass("hidden")` (the click handler that opens the readout, and the Macrostrat/out-of-state paths — there are three) and every `$("#unitsPane").hide()` with `$("#unitsPane").addClass("hidden")` (the `#fms-close` handler and `toggleMapDl`). Leave existing `addClass("hidden")` calls as-is.
+
+- [ ] **Step 3: Syntax check.** Run: `node --check public/mapcontrols.js` (exit 0); confirm `style.css` braces balance.
+
+- [ ] **Step 4: Manual check.** Local browser. Open the readout, scroll a long section: the close "✕" stays pinned (does not scroll away). Confirm the panel still opens on click and closes via ✕, and that switching to/from any other tool still hides/shows it.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/style.css public/mapcontrols.js
+git commit -m "feat(readout): pin panel header/close via flex layout + class-based show/hide"
+```
+
+---
+
+### Task 8: Verification matrix + pre-commit review
+
+**Files:** none unless fixes are needed.
+
+- [ ] **Step 1: Run the full matrix** locally (`npx firebase serve`):
+  - Desktop ≥768px: two-column section, full description, rail with publication link + downloads (icons) + citation (copy works) + tools (pan/zoom/share); single scrollbar; pinned ✕.
+  - Mobile <768px: bottom sheet, one column, description clamps with "Show more", groups collapse/expand.
+  - `units==='True'` (`M-300DM`): description + **DOI Link** + downloads.
+  - `units!=='True'` UGS/UGMS (`Q-2thru5`): publication note + **DOI Link** + PDF/GeoTIFF + multi-author citation.
+  - non-UGS (`I-2462`, USGS): **Publication Page** (not DOI) + any downloads.
+  - Multiple maps at a point: accordion of others; opening one renders the same responsive body; clicked map stays default-open.
+  - Cross-section viewer opens; "Copy link" yields `…?view=scene&sid=…&layers=…`.
+
+- [ ] **Step 2: Final checks.** `node --check public/mapcontrols.js` (exit 0); `style.css` braces balance.
+
+- [ ] **Step 3: Pre-commit review.** Per repo convention, run a code-review subagent and a frontend reviewer on the cumulative diff (`git diff origin/dev...HEAD`): correctness (the two render paths don't regress the 500k / Macrostrat / out-of-state cases; delegation handlers; class-based show/hide doesn't break any visibility check), and layout (single-scroll, responsive grid, sticky close, zoom). Address every finding in the same pass.
+
+- [ ] **Step 4: Commit any review fixes**, then stop — open the PR into `dev` only on the user's go-ahead.
+
+```bash
+git add -A
+git commit -m "fix(readout): address review findings on the consolidated panel"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** consolidated section both `units` paths (Task 3); downloads/citation/tools + parity (Tasks 3–4, function table → `renderResources`); responsive 2-col/disclosure (Task 5); single scroll (Task 6); sticky header (Task 7); prefetch-all (Task 2); citation/pub-link helpers reused (Task 1); a11y (`aria-expanded`, real buttons) + reduced-motion + mobile truncation (Task 5); icon reuse (Task 3 classes + Task 5 styling); panel widen/opacity/bottom sheet (Task 6); verification matrix + review (Task 8). Card removal + layer-list reorg explicitly deferred (out of scope, per spec). Covered.
+- **Placeholders:** none — every code step has concrete code; every command has expected output.
+- **Type/name consistency:** `buildCitation`, `buildPubLink`, `renderResources`, `fillResources`, `getPubData`, `prefetchPubData`, `accordionFtrs`, and the CSS class names (`readout-section-body`, `readout-main`, `readout-resources`, `readout-group`/`-toggle`/`-content`, `res-downloads`/`-cite`/`-copy`/`-tools`/`-tool`/`-pan`/`-zoom`/`-share`/`-xsec`, `readout-show-more`) are used consistently across tasks. The `data-idx` lookup in Task 4 matches the `data-idx` emitted by `buildAccordion` on `.map-section-readout`.
+- **Risk note:** Task 7's class-based show/hide must replace *all* `#unitsPane` `.show()`/`.hide()` calls; a missed one would leave the panel stuck. Grep `rg "#unitsPane"` before committing Task 7 to confirm none remain on `.show()/.hide()`.

--- a/docs/plans/2026-06-08-readout-visual-redesign.md
+++ b/docs/plans/2026-06-08-readout-visual-redesign.md
@@ -1,0 +1,211 @@
+# Readout Visual Redesign ("Refined Light") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the approved "Refined Light" visual polish to the click-readout panel — crisp inline-SVG resource icons, a stronger blue header with an accent bar, an accented unit symbol, a "Resources" label, and a visible-but-muted grayed state — with no behavioral change.
+
+**Architecture:** Two files only — `public/mapcontrols.js` (`renderResources` + the unit-title markup in `loadUnitDescription`) and `public/style.css` (the `.readout-*` / `.res-*` rules). The legacy `.pdfIcon`/`.gisIcon`/… PNG classes stay in CSS (still used by the not-yet-removed Map Downloads card `printPubs`); the readout simply stops using them in favor of inline SVG drawn with `currentColor` so the chip color drives the icon.
+
+**Tech Stack:** Vanilla JS (ArcGIS Maps SDK + jQuery) + CSS, inline SVG. No new libraries, no build step.
+
+**Testing note:** This repo has no frontend test runner (`npm test` is a no-op). Per-task checks are `node --check public/mapcontrols.js` (JS parses) and CSS brace balance. Full visual fidelity is verified on the **preview channel** after the PR build (Task 3). Node 24/25 locally breaks the Firebase CLI but NOT `node --check`; if `node --check` ever complains, use `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --check …`.
+
+Spec: `docs/specs/2026-06-08-readout-visual-redesign-design.md`. Branch: `feat/readout-redesign`.
+
+---
+
+## File structure
+
+- **Modify** `public/mapcontrols.js` — add a module-level `RES_ICONS` map (type → inline SVG string); rewrite the `renderResources` chip builder to emit SVG + a "Resources" label and drop the legacy icon classes; accent the unit symbol/age in `loadUnitDescription`'s title.
+- **Modify** `public/style.css` — `.res-chip`/`.res-chip-off` (flex + SVG, no background-image, grayed = gray currentColor); `.res-label`; `.readout-primary-head` accent bar + title color/size; `.unit-desc-title .ud-sym`/`.ud-age`.
+
+No new files. No `package.json` change.
+
+Out of scope (separate specs): the dark theme, Map Downloads card removal, layer-list/tools reorg.
+
+---
+
+### Task 1: Inline-SVG resource icons (replace the faint PNG glyphs)
+
+**Files:** Modify `public/mapcontrols.js`, `public/style.css`.
+
+- [ ] **Step 1: Add the `RES_ICONS` map** immediately above `function renderResources` in `public/mapcontrols.js` (it currently starts with the comment `// the resources block (publication link, downloads, citation, map tools) for one section.`). Insert before that comment:
+
+```js
+// inline resource icons, drawn with currentColor so the chip's text color drives the icon
+// (active = link blue, unavailable = gray). Replaces the faint background-PNG glyphs in the readout.
+var RES_ICONS = {
+    pdf:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M6 2.5h7l5 5V21.5H6z"/><path d="M13 2.5V8h5"/><path d="M9 13h6M9 16.5h6" stroke-width="1.3"/></svg>',
+    gis:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M12 3l9 4.5-9 4.5-9-4.5z"/><path d="M3 12l9 4.5 9-4.5"/><path d="M3 16.5l9 4.5 9-4.5"/></svg>',
+    tiff: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="8.5" cy="10" r="1.6" fill="currentColor" stroke="none"/><path d="M5 17.5l4.5-5 3 3.5L16 11l3.5 6.5"/></svg>',
+    xsec: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 16c3-8 6-8 9 0s6 5 9-3"/><path d="M3 8.5h18"/></svg>',
+    lith: '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="3" width="10" height="4.2" rx="1"/><rect x="7" y="9" width="10" height="5.4" rx="1"/><rect x="7" y="16" width="10" height="5" rx="1"/></svg>',
+    pur:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M3.5 4h2l2.2 10.5h9.3L19 7H7"/><circle cx="10" cy="19.5" r="1.4" fill="currentColor" stroke="none"/><circle cx="17" cy="19.5" r="1.4" fill="currentColor" stroke="none"/></svg>'
+};
+```
+
+- [ ] **Step 2: Rewrite the chip section of `renderResources`.** Replace the existing `items` array + `chips` builder (the block from `var items = [` through the `.join('');` that ends the `chips` assignment) with:
+
+```js
+    // consistent resource set: every map shows all six types so layouts match and "grayed" reads as
+    // "this map doesn't have it" (not "broken"). href = external download/link; img = in-app viewer.
+    var items = [
+        { ic: 'pdf',  label: 'PDF',               href: (rec && rec.pub_url)   ? rec.pub_url : '' },
+        { ic: 'gis',  label: 'GIS data',          href: (rec && rec.gis_data)  ? base + rec.gis_data : '' },
+        { ic: 'tiff', label: 'GeoTIFF',           href: (rec && rec.geotiff)   ? base + rec.geotiff : '' },
+        { ic: 'xsec', label: 'Cross-section',     img:  (rec && rec.x_section) ? base + rec.x_section : '' },
+        { ic: 'lith', label: 'Lithologic column', img:  (rec && rec.lith_col)  ? base + rec.lith_col : '' },
+        { ic: 'pur',  label: 'Purchase',          href: (rec && rec.bsurl)     ? 'https://utahmapstore.com/products/' + sid : '' }
+    ];
+    var chips = items.map(function (it) {
+        var icon = RES_ICONS[it.ic];
+        if (it.href) return '<a class="res-chip" target="_blank" rel="noopener" href="' + it.href + '">' + icon + '<span>' + it.label + '</span></a>';
+        if (it.img)  return '<a class="res-chip res-img" href="#" data-img="' + it.img + '">' + icon + '<span>' + it.label + '</span></a>';
+        return '<span class="res-chip res-chip-off" title="Not available for this map">' + icon + '<span>' + it.label + '</span></span>';
+    }).join('');
+```
+
+(The label is wrapped in `<span>` so the chip is exactly two flex children — icon + label.)
+
+- [ ] **Step 3: Update the resource-chip CSS.** In `public/style.css`, replace the `.res-chip` rule and the `.res-chip-off` rule. The current rules are:
+
+```css
+.res-chip { font-size: 12px; line-height: 24px; min-height: 24px; display: flex; align-items: center; color: #326A98; text-decoration: none; background-repeat: no-repeat; background-position: left center; background-size: 22px 22px; padding-left: 28px; }
+.res-chip:hover { color: #1d4e78; text-decoration: underline; }
+.res-chip-off { color: #8a8a8a; cursor: not-allowed; filter: grayscale(1); opacity: 0.8; }
+.res-chip-off:hover { color: #8a8a8a; text-decoration: none; }
+```
+
+Replace those four lines with:
+
+```css
+.res-chip { font-size: 12.5px; min-height: 24px; display: flex; align-items: center; gap: 8px; color: #326A98; text-decoration: none; }
+.res-chip svg { flex: none; }
+.res-chip span { min-width: 0; overflow-wrap: anywhere; }
+.res-chip:hover { color: #1d4e78; }
+.res-chip:hover span { text-decoration: underline; }
+.res-chip-off { color: #8d8d8d; cursor: not-allowed; }
+.res-chip-off:hover span { text-decoration: none; }
+```
+
+- [ ] **Step 4: Checks.** Run `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --check public/mapcontrols.js` (expect no output, exit 0) and confirm braces balance:
+
+```bash
+[ "$(tr -cd '{' < public/style.css | wc -c)" = "$(tr -cd '}' < public/style.css | wc -c)" ] && echo balanced
+```
+Expected: `balanced`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/mapcontrols.js public/style.css
+git commit -m "feat(readout): crisp inline-SVG resource icons (currentColor), grayed = gray"
+```
+
+---
+
+### Task 2: Header accent, unit-symbol accent, and "Resources" label
+
+**Files:** Modify `public/mapcontrols.js`, `public/style.css`.
+
+- [ ] **Step 1: Add the "Resources" label** to `renderResources`'s return in `public/mapcontrols.js`. The current final line is:
+
+```js
+    return '<div class="res-grid">' + chips + '</div>' + pubLink + cite + tools;
+```
+
+Replace it with:
+
+```js
+    return '<div class="res-label">Resources</div><div class="res-grid">' + chips + '</div>' + pubLink + cite + tools;
+```
+
+- [ ] **Step 2: Accent the unit symbol/age** in `loadUnitDescription`. The current title line is:
+
+```js
+                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp;' + unit.unit_name + '&nbsp;(' + unit.age + ')</div><hr>' +
+```
+
+Replace it with:
+
+```js
+                    '<div class="unit-desc-title"><span class="ud-sym">' + unit.unit_symbol + '</span>:&nbsp;' + unit.unit_name + '&nbsp;<span class="ud-age">(' + unit.age + ')</span></div><hr>' +
+```
+
+- [ ] **Step 3: Add the header/hierarchy CSS.** In `public/style.css`:
+
+(a) Replace the `.readout-primary-head` and `.readout-primary-title` rules. Current:
+
+```css
+.readout-primary-head { position: sticky; top: 0; z-index: 1; display: flex; align-items: center; gap: 10px; background: #fff; padding: 0 28px 6px 0; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+.readout-primary-title { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
+```
+
+Replace with (adds `position: relative` is unnecessary — `sticky` already establishes positioning — so the `::after` anchors to the head):
+
+```css
+.readout-primary-head { position: sticky; top: 0; z-index: 1; display: flex; align-items: center; gap: 10px; background: #fff; padding: 0 28px 7px 0; border-bottom: 1px solid #ededed; margin-bottom: 8px; }
+.readout-primary-head::after { content: ""; position: absolute; left: 0; bottom: -1px; width: 54px; height: 2px; background: #326A98; border-radius: 2px; }
+.readout-primary-title { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 18px; letter-spacing: .4px; line-height: 1.08; color: #235c87; overflow-wrap: anywhere; }
+```
+
+(b) Add the unit-symbol/age + "Resources" label rules. Insert them immediately after the existing `.readout-main hr { … }` line:
+
+```css
+.unit-desc-title .ud-sym { color: #326A98; }
+.unit-desc-title .ud-age { font-weight: 400; color: #777; }
+.res-label { margin: 14px 0 6px; font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; }
+```
+
+- [ ] **Step 4: Checks.** `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --check public/mapcontrols.js` (exit 0); braces:
+
+```bash
+[ "$(tr -cd '{' < public/style.css | wc -c)" = "$(tr -cd '}' < public/style.css | wc -c)" ] && echo balanced
+```
+Expected: `balanced`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add public/mapcontrols.js public/style.css
+git commit -m "feat(readout): blue header with accent bar, accented unit symbol, Resources label"
+```
+
+---
+
+### Task 3: Verification matrix + pre-commit review
+
+**Files:** none unless fixes are needed.
+
+- [ ] **Step 1: Push and open/refresh the preview.** The branch `feat/readout-redesign` already exists; pushing re-runs the per-PR preview build. If no PR is open yet for this branch, open one into `dev` (title `feat(readout): Refined Light visual redesign`); otherwise just `git push`. Capture the `…--<branch>-<hash>.web.app` preview URL from the PR's `build_and_preview` run comment.
+
+```bash
+git push
+```
+
+- [ ] **Step 2: Run the visual matrix** on the preview URL (real ArcGIS layers load there):
+  - Click a **unit map** (e.g. Provo 24k / `M-249`): the **accent bar** sits under the blue title; the **unit symbol** is blue, age muted; a **"RESOURCES"** label precedes the grid; the six chips show **crisp colored SVG icons**; available chips are link-blue, **grayed chips (e.g. GeoTIFF) are a clear medium gray** with the "not available" tooltip; **DOI Link: https://doi.org/…** is written out above the citation; the **Copy** button is visible; Pan/Zoom/Copy link/Preview work.
+  - A **no-unit / pub-only map** (`MP-17-2DM`): resources still render (empty-state path) with the same icons/label.
+  - A **non-UGS map** (USGS): shows **Publication Page** (a plain hyperlink, not the written-out DOI).
+  - **Mobile** (narrow window / bottom sheet): chips wrap to fewer columns; icons + grayed state still read; title-row toggle intact.
+  - The **image viewer** (cross-section / lith column / preview) still opens and closes on Esc / any click.
+
+- [ ] **Step 3: Final static checks.** `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --check public/mapcontrols.js` (exit 0); `style.css` braces balance.
+
+- [ ] **Step 4: Pre-commit review** (repo convention). Run a code-review subagent and a frontend reviewer on the cumulative diff (`git diff feat/consolidated-readout-panel...HEAD`): correctness (the SVG chip markup is exactly icon+label; `currentColor` makes active blue / off gray; the `.pdfIcon` legacy classes are untouched so `printPubs` still works; `loadUnitDescription`'s no-unit/catch branches still render resources), and visual soundness (icon legibility at 20px and in gray, header accent, hierarchy, mobile wrap). Address every finding in the same pass.
+
+- [ ] **Step 5: Commit any review fixes.**
+
+```bash
+git add -A
+git commit -m "fix(readout): address review findings on the visual redesign"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** header (title blue `#235c87` + accent bar) → Task 2; inline-SVG iconography replacing PNGs with `currentColor`, grayed-visible → Task 1; hierarchy (accented symbol, "Resources" label, spacing) → Task 2; preserved DOI/Copy/toggle/viewer/grid/empty-state → untouched by design (verified Task 3); scope/constraints (vanilla, no libs, visual only) → respected (only `.res-*`/`.readout-*` + `renderResources`/`loadUnitDescription` touched). Covered.
+- **Placeholders:** none — every code step has complete copy-pasteable code; every check has an exact command + expected output.
+- **Type/name consistency:** `RES_ICONS` keys (`pdf`/`gis`/`tiff`/`xsec`/`lith`/`pur`) match the `it.ic` values in the `items` array; `.res-chip`/`.res-chip-off`/`.res-label`/`.ud-sym`/`.ud-age` are used consistently between the JS that emits them (Tasks 1–2) and the CSS that styles them (Tasks 1–2). The `res-img` class + `data-img` (image-viewer handler) are preserved unchanged.
+- **Risk:** the SVG icons must read at 20px and when gray — Task 3 verifies on the dev preview and allows path tuning.

--- a/docs/specs/2026-06-06-consolidated-readout-panel-design.md
+++ b/docs/specs/2026-06-06-consolidated-readout-panel-design.md
@@ -1,0 +1,283 @@
+# Consolidated Feature Readout Panel — Design Spec
+
+**Date:** 2026-06-06
+**Status:** Proposed — design approved in discussion; pending spec review.
+**Branch:** `feat/consolidated-readout-panel` (off `dev`).
+
+## Goal
+
+Fold everything the separate "Map Downloads" card provides (downloads, citation,
+and per‑map actions) into the click‑driven unit‑description readout, so a single
+panel answers "what unit is here, from which map, and what can I do with that
+map." Use the space reclaimed from the card with a **responsive** layout, and
+collapse the readout to **one** scroll container so the multi‑scrollbar confusion
+goes away. Vanilla only — this is a stopgap ahead of the eventual MapLibre/React
+(ugs‑map‑viewer) migration; **no new libraries, no build step**.
+
+## Background — current state (on `dev`)
+
+- **Readout** (`public/mapcontrols.js`): a map click runs `fetchAttributes()`,
+  which sorts the footprints at the point and renders `buildAccordion()` into
+  `#udTab` inside `#unitsPane`. The clicked map is the open primary section; other
+  maps are collapsed accordion cards (single‑open). Each section lazy‑loads via
+  `loadSection()` → `loadUnitDescription()` (`units==='True'`) or
+  `loadPublicationOnly()` (others). Today a section shows: unit identity
+  (symbol/name/age), description, a reference line (**DOI Link** for UGS/UGMS,
+  **Publication Page** for others), and a "Show on map" layer toggle.
+- **Map Downloads** (separate mode): `#identifyPanel` toggles Unit Descriptions ↔
+  Map Downloads (`toggleUnitDesc()` / `toggleMapDl()`); Map Downloads shows the
+  footprints layer plus a Swiper carousel (`#mapsPane`) built by `printPubs()`.
+  Each carousel slide carries: a publication‑page title link, share actions
+  (shareable link, pan‑to, zoom‑to; pin / "list maps" are already hidden), the
+  citation (`reftxt`, with copy‑to‑clipboard), a preview thumbnail, and download
+  links (PDF / GIS / GeoTIFF / Cross‑section / Purchase).
+- **Data sources:**
+  - Unit description (`units==='True'`): pg_featureserv
+    `unit_desc_sym_age_by_point_scale` → `unit_symbol`, `unit_name`, `age`,
+    `unit_description`.
+  - Publication record: the Firebase `getData` function
+    (`${projectName}/getData?mapid=<series_id>`; multiple `mapid` allowed) →
+    `pub_url` (PDF), `gis_data`, `geotiff`, `x_section`, `lith_col`,
+    `bsurl`/bookstore, `pub_thumb` (preview), `pub_publisher`, `pub_author`,
+    `pub_sec_author`, `pub_year`, `pub_name`, `pub_scale`, `series_id`,
+    `quad_name`. Memoized + prefetched today by `prefetchPubData()` /
+    `getPubData()` — but only for `units!=='True'` footprints.
+  - Footprint attributes (footprints layer): `series_id`, `quad_name`, `scale`,
+    `units`, `geomaps_service`, `pub_year`, `resturl`, plus the feature geometry
+    (used for extent / pan‑zoom).
+  - Derived links: DOI `https://doi.org/10.34191/<series_id>` (UGS/UGMS);
+    publication page `https://geology.utah.gov/publication-details/?pub=<series_id>`
+    (others); purchase `https://utahmapstore.com/products/<series_id>`; file
+    downloads under `https://ugspub.nr.utah.gov/publications/<path>`.
+
+## Non‑goals (out of scope for this spec)
+
+- The **layer‑list / tools reorg** (`#layersPanel`, transparency, the footprint
+  scale‑filter buttons `#btn-*`). That is the next item‑6 sub‑project with its
+  own spec.
+- The **MapLibre/React migration**. This panel is a deliberate vanilla stopgap.
+- A fully mobile‑native experience (gesture bottom sheet, etc.) — we do a
+  pragmatic responsive treatment only.
+- Changing the data sources/endpoints or the footprint/publication schemas.
+
+## Design overview
+
+One panel, one scrollbar, **responsive disclosure**:
+
+- On a **wide** viewport the panel widens into the reclaimed card space and an
+  open section is **two columns** — description on the left, a "resources rail"
+  (publication link, downloads, citation, tools, layer toggle) on the right. The
+  rail means no expanders are needed on desktop: more is visible, fewer clicks.
+- On a **narrow** viewport the panel becomes a full‑width bottom sheet, the
+  section is **one column**, the resources collapse back into progressive‑
+  disclosure groups ("Downloads & citation", "Map tools"), and the description
+  truncates with "Show more".
+- Same DOM in both cases — CSS breakpoint flips columns ↔ stacked. No JS layout
+  branching, no library.
+
+### Responsive rules (concrete)
+
+- Breakpoint: **768px** viewport width (matches ugs‑map‑viewer's `useIsMobile`,
+  for forward consistency).
+- **≥768px (desktop):** `#unitsPane` width ≈ **440px** (up from 300px), opacity
+  raised from 0.85 → **0.96** (download/citation text must be crisp). Open
+  section body = CSS grid, two columns ≈ 60% description / 40% resources rail
+  (rail min ~165px). Description shown **in full** (it has its own column; the
+  panel scrolls if needed).
+- **<768px (mobile):** `#unitsPane` becomes a bottom‑anchored, full‑width sheet
+  (max‑height ≈ 70vh). Single column. Resources render as collapsible groups.
+  Description truncates to ~5 lines with a "Show more"/"Show less" toggle.
+- **Stretch (optional, not required for parity):** a drag handle to resize the
+  desktop panel width, persisted to `localStorage`. Marked optional so the core
+  ships without it.
+
+### Scroll model
+
+- `#unitsPane` is the **single** scroll container (`overflow-y:auto`,
+  `max-height`). No inner `vh`‑capped scroll boxes (removes the
+  `.map-readout` / `.readout-others` / `.map-section-readout` nested scrolls that
+  caused the multi‑scrollbar confusion and the zoom clipping).
+- Because every section is compact by default (full‑but‑single‑column or
+  two‑column rail; expanders collapsed on mobile; description truncated on
+  mobile), the clicked map and the collapsed "other maps" headers fit with one
+  scrollbar; you only scroll when you deliberately expand/expand a long
+  description.
+- The **panel header** (clicked‑map title + close ✕) is `position:sticky` at the
+  top of the scroll container, so close is always reachable (also resolves the
+  earlier "close button scrolls away" issue).
+
+## Section anatomy
+
+### `units==='True'` (has a unit description)
+
+Header (accordion trigger): `1:24,000 · Provo · M-249 · 1991` + chevron + (when
+its category has a real layer) the "Show on map" toggle.
+
+Open body:
+- **Unit identity:** `Qal: Alluvium (Holocene)` (`.unit-desc-title`).
+- **Description:** full on desktop; truncated + "Show more" on mobile.
+- **Resources** (rail on desktop / collapsible groups on mobile):
+  - **Publication link:** "DOI Link" (UGS/UGMS) or "Publication Page" (others) —
+    the existing publisher‑aware logic.
+  - **Downloads:** PDF · GIS data · GeoTIFF · Cross‑section · Purchase — only the
+    ones present for that map; each an icon + label (see Icon reuse). Cross‑
+    section opens the existing image viewer (`#xsection-pane`).
+  - **Citation:** the `reftxt` string (author[, and sec_author], year, name,
+    series_id, publisher, scale) with a copy‑to‑clipboard control.
+  - **Map tools:** Pan to · Zoom to (the map's footprint extent) · Copy shareable
+    link · Preview (thumbnail from `pub_thumb`).
+
+### `units!=='True'` (publication‑only; no unit description)
+
+- No left description column → the section leads with the resources (downloads
+  are the point). Keep the short note "Tabular GIS data has not been generated
+  for this map; see the publication." + the publication link, then Downloads /
+  Citation / Map tools as above.
+- On desktop this is effectively a single wide resources block (no 2‑col split).
+
+### "Other maps at this location"
+
+- Unchanged structure: a single‑open accordion of collapsed headers below the
+  primary. Opening one gives it the same responsive section body. The clicked
+  map remains the default‑open primary on top.
+
+## Functions carried over from the Map Downloads card
+
+| Card function | New home | Source |
+|---|---|---|
+| Publication page title link | Resources → publication link | derived (publisher) |
+| PDF | Downloads | `getData.pub_url` |
+| GIS data | Downloads | `getData.gis_data` |
+| GeoTIFF | Downloads | `getData.geotiff` |
+| Cross‑section (+ viewer) | Downloads (opens `#xsection-pane`) | `getData.x_section` |
+| Purchase | Downloads | `utahmapstore.com/products/<series_id>` (gated by `bsurl`) |
+| Citation (+ copy) | Resources → citation | `reftxt` (reuse, incl. sec‑author join) |
+| Preview image | Map tools → Preview | `getData.pub_thumb` |
+| Shareable link | Map tools | existing `?view=scene&sid=…&layers=…` + `copyToClipboard` |
+| Pan to / Zoom to | Map tools | footprint feature extent |
+| Footprint highlight | automatic on section open/hover | footprint geometry |
+| Pin / "list maps on screen" | dropped | already hidden today |
+
+## Icon reuse
+
+Reuse the existing download glyph classes from the card (`pdfIcon`, `gisIcon`,
+`tiffIcon`, `xsecIcon`, `purIcon`) and the existing tool/share icon styles so the
+consolidated panel matches the app and needs **no new assets**. The cross‑section
+download reuses the current `#xsection-pane` viewer wiring.
+
+## DOM / CSS approach
+
+- Extend `buildAccordion()` section markup to emit the resources block. New
+  containers (illustrative class names): `.readout-resources` (the rail/groups
+  wrapper), `.readout-downloads`, `.readout-citation`, `.readout-tools`, plus
+  disclosure groups `.readout-group[aria-expanded]` for the mobile collapsibles.
+- Responsive layout via a CSS grid on the open section body
+  (`grid-template-columns: 1fr` mobile → `minmax(0,1.4fr) minmax(165px,1fr)`
+  desktop) behind the 768px media query. The mobile collapsibles are hidden
+  on desktop (the rail shows the same content expanded) — same content, CSS
+  controls presentation.
+- Remove the nested `vh` scroll caps introduced for the pinned layout; make
+  `#unitsPane` the single scroller; make the header sticky.
+- Keep all rendering in `mapcontrols.js`/`style.css` (the established single‑file
+  pattern); no framework, no build.
+
+## Data fetching
+
+- Extend `prefetchPubData()` to warm `getData` for **all** footprints at the
+  point (not just `units!=='True'`), since every section now shows
+  downloads/citation. `getData` already accepts batched `mapid`s and the result
+  is memoized by `series_id`.
+- The DOI/Publication‑Page link renders immediately from `series_id` +
+  publisher; file downloads/citation/preview render when the (prefetched)
+  `getData` record resolves.
+- Reuse the citation builder (the `pub_author` + smart‑"and" `pub_sec_author`
+  join already added in PR #144) — extract it into a small shared helper so both
+  the readout and (temporarily) `printPubs` use one implementation.
+
+## Accessibility & polish ("make it awesome")
+
+- Disclosure groups are real buttons with `aria-expanded`/`aria-controls`;
+  keyboard operable; visible focus rings (the accordion already does this).
+- Smooth height/opacity transitions on expand/collapse and on the description
+  "Show more".
+- Crisp typography hierarchy: section header (Bebas) > unit identity (the smaller
+  weight from PR #144) > body; downloads as scannable icon+label rows; citation
+  in a muted, monospace‑free small style with an obvious copy affordance.
+- Loading and empty states per section (spinner while `getData` resolves;
+  graceful "no downloads available" when a map has none).
+- Respect `prefers-reduced-motion` for the transitions.
+
+## Retiring Map Downloads (sequenced follow‑up — not this spec's build)
+
+Once a consolidated section reaches parity with the card (verified on the dev
+site), a small follow‑up removes the `#identifyPanel` toggle,
+`toggleUnitDesc()`/`toggleMapDl()`, the `#mapsPane` Swiper, and `printPubs()`,
+and makes the readout the single experience. Kept separate so we don't delete the
+card until parity is proven, and so the footprints‑layer / scale‑filter‑button
+handling can be addressed with the layer‑list reorg. The citation's only other
+home is the readout, so it must be live there first.
+
+## Tech constraints
+
+- Vanilla JS (ArcGIS Maps SDK + jQuery), Firebase Hosting + Cloud Functions,
+  pg_featureserv, AGOL footprints. No new runtime dependency. No build step.
+- `node --check public/mapcontrols.js` must pass; CSS brace‑balanced.
+
+## Testing (manual — no frontend test runner in this repo)
+
+Verify on the **dev site** (auto‑deploys from `dev`); local `firebase serve`
+can't render the secured ArcGIS geology layers (see auto‑memory). Cases:
+- Desktop ≥768px: two‑column section; full description; rail shows publication
+  link + downloads + citation (copy works) + tools (pan/zoom/share/preview);
+  single scrollbar; sticky header/close.
+- Mobile <768px: bottom sheet; one column; description truncates with Show
+  more; resources collapse into groups; single scrollbar.
+- A `units==='True'` map (e.g. `M-300DM`): description + DOI Link + downloads.
+- A `units!=='True'` UGS/UGMS map (`Q-2thru5`): Publication‑only note + DOI Link
+  + PDF/GeoTIFF + citation incl. secondary authors.
+- A non‑UGS map (`I-2462`, USGS): Publication Page (not DOI) + whatever
+  downloads exist.
+- Multiple maps at a point: accordion of others; opening one renders the same
+  responsive body; clicked map stays the default‑open primary.
+- Zoom Chrome to ~150–175%: nothing clipped; one scrollbar.
+
+## Decisions (resolved)
+
+- Density: compact, progressive disclosure.
+- Responsive: columns on desktop / stacked + expanders on mobile, 768px.
+- Description: full on desktop, truncate on mobile.
+- Panel: ~440px desktop / full‑width bottom sheet mobile; opacity → 0.96.
+- Scroll: single container + sticky header.
+- Drag‑to‑resize: optional stretch, not required for parity.
+- Map Downloads removal: sequenced follow‑up after parity.
+
+## Open questions
+
+- None blocking. (Exact desktop width, rail ratio, and truncation line‑count are
+  tunable during implementation against the dev site.)
+
+## Risks
+
+- Two readout render paths (`loadUnitDescription` / `loadPublicationOnly`) must
+  both adopt the resources block without regressing the existing description /
+  500k / Macrostrat / out‑of‑state paths.
+- Prefetching `getData` for all footprints slightly increases requests at click
+  time (bounded by # maps at a point; memoized) — acceptable.
+- The footprint feature geometry must be retained through `accordionFtrs` for
+  pan/zoom/extent; confirm `returnGeometry` on the click query during
+  implementation.
+- This is throwaway at migration — keep it contained; resist scope creep into the
+  layer‑list reorg.
+
+## Self‑review
+
+- Spec coverage: consolidated section (anatomy, both `units` paths), responsive
+  columns + disclosure, single‑scroll + sticky header, function parity table +
+  data sources, icon reuse, prefetch extension, citation helper extraction,
+  a11y/polish, retirement sequencing, testing, constraints. Covered.
+- Placeholders: none.
+- Consistency: 768px breakpoint, ~440px width, 0.96 opacity, and the single‑
+  scroll model are stated once and reused; function table maps every card
+  feature to a home + source.
+- Scope: focused on the consolidated readout + scroll; layer‑list reorg and the
+  actual card removal are explicitly deferred.

--- a/docs/specs/2026-06-08-readout-visual-redesign-design.md
+++ b/docs/specs/2026-06-08-readout-visual-redesign-design.md
@@ -1,0 +1,93 @@
+# Readout Visual Redesign ("Refined Light") — Design Spec
+
+**Date:** 2026-06-08
+**Status:** Approved in brainstorm (visual companion, Direction A); pending spec review.
+**Branch:** `feat/readout-redesign` (off `feat/consolidated-readout-panel` / PR #151).
+
+## Goal
+
+An eye-catching but professional **visual polish** of the click-readout panel
+(already built in #151) in the "Refined Light" direction: stronger header, crisp
+colored iconography, clearer hierarchy, visible-but-muted grayed chips, more
+breathing room. **Look-and-feel only** — no structural or behavioral change.
+
+## Scope
+
+- **In:** the readout panel's visual styling (`public/style.css` `.readout-*` /
+  `.res-*` / `#unitsPane`) and the resource-chip iconography in
+  `public/mapcontrols.js` (`renderResources`).
+- **Out (separate efforts, do not touch here):** the dark theme, Map Downloads
+  card removal, layer-list / tools reorg. **No new libraries, no build step.**
+
+## Approved direction — "Refined Light"
+
+Light panel (white, opacity ~0.96–1 for crisp text), a tightened UGS-blue accent
+system:
+
+- Title / header text: deeper blue `#235c87` (Bebas Neue).
+- Accent + icons: `#326A98`.
+- Toggle "on": `#6396fc`.
+- Body: `#2a2a2a`; description `#3c3c3c`; muted labels `#9aa0a6`; grayed `#8d8d8d`.
+- Hairlines `#ededed`; tool/copy chips `#f4f7fb` bg / `#cdd8e3` border / `#235c87` text.
+
+## Concrete changes
+
+### 1. Header (`.readout-primary-head`, `.map-section-header`)
+- Primary title in `#235c87`, Bebas ~18.5px.
+- A short **accent bar** under the primary header: 2px `#326A98`, ~54px wide,
+  left-aligned (via `::after`) sitting on the existing hairline.
+- Keep the title-row layer toggle (right), sticky header, and close-button clearance.
+
+### 2. Iconography — replace the faint PNG glyphs with inline SVG
+- The legacy `.pdfIcon/.gisIcon/.tiffIcon/.xsecIcon/.purIcon` background-PNGs (the
+  ones that were too light/small) are replaced by **inline SVG** icons emitted in
+  `renderResources`, ~20px, drawn with `currentColor` so the chip's color drives them:
+  - PDF → document · GIS data → layers · GeoTIFF → image · Cross-section → section
+    wave · Lithologic column → stacked bars · Purchase → cart.
+- Chip becomes a flex row: `svg` + label. Active = `#326A98`; **grayed**
+  (`.res-chip-off`) = `filter: grayscale(1); opacity: .55` + `#8d8d8d` text — clearly
+  unavailable but legible, keeping the existing "Not available for this map" tooltip.
+- Implementation: a small `RES_ICONS` map (type → inline SVG string) in
+  `mapcontrols.js`; the chip builder picks the icon by type. No dependency added.
+
+### 3. Hierarchy & spacing
+- Unit identity: symbol accented (e.g. `Qal` in `#326A98`), name bold, age muted gray.
+- A small uppercase **"Resources"** label (`#9aa0a6`, letter-spacing) above the grid.
+- More vertical breathing room between blocks (description → resources → DOI →
+  citation → tools) with subtle hairlines.
+
+### 4. Preserved exactly (no change)
+Single-column layout; the consistent six-type resource grid + grayed-when-absent
+logic; the **written-out DOI above the citation** (`buildPubLink`; non-UGS stays a
+plain "Publication Page" hyperlink); the visible "Copy" citation button; the
+click-anywhere / Esc image viewer; the title-row toggle (with click
+`stopPropagation`); the description clamp + Show more; the empty-state that still
+renders a map's resources when no unit sits under the click.
+
+## Implementation notes
+
+- Mostly `public/style.css`; one focused `renderResources` change to emit SVG chips.
+- After edits: `node --check public/mapcontrols.js`; confirm `style.css` braces balance.
+- The real look is verified on the **preview channel** (build → push → review on the
+  PR), not in the companion. Build happens on `feat/readout-redesign`.
+
+## Testing (manual — no frontend test runner)
+
+On the preview channel: desktop + mobile (bottom sheet); a unit map (M-249), a
+no-unit / pub-only map (MP-17-2DM), and a non-UGS map (shows "Publication Page").
+Confirm: icons are crisp + colored; grayed chips legible; header accent + hierarchy
+read well; DOI / citation / tools all intact; sticky header + toggle unaffected.
+
+## Out of scope / risks
+
+- Do not drift into the card removal or layer-list reorg.
+- SVG icons must read clearly at ~20px and in grayscale; tune the paths against the
+  dev preview.
+
+## Self-review
+
+- **Placeholders:** none.
+- **Consistency:** the blue palette and the preserved-list match the approved mockup.
+- **Scope:** focused on the readout's visual layer; the two structural pieces are
+  explicitly deferred to their own specs.
+- **Ambiguity:** the icon set is enumerated per resource type; colors are concrete hex.

--- a/public/index.html
+++ b/public/index.html
@@ -239,7 +239,6 @@
         <a id="survey-button" class="survey" href="https://forms.gle/3yunpY49FbWamgrQ8" target="_blank">Give Feedback</a>
 
         <!-- map scale and lat/long for mouse position on the map -->
-        <a class="ugs-watermark " href="https://geology.utah.gov"></a>
         <div class="mouse-info">
             <div class="scale">view scale:&nbsp;1:6,470,000</div>
             <div class="mouseposition">Lat:&nbsp;39&deg; 35.21&nbsp;&nbsp;Long:&nbsp;111.86</div>

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2113,18 +2113,25 @@ function buildCitation(rec) {
 // rec is the getData record (may be null while loading / if the map has no record).
 function renderResources(rec, atts) {
     var sid = atts.series_id;
+    var base = 'https://ugspub.nr.utah.gov/publications/';
+    // publisher-aware: UGS/UGMS -> DOI Link; other publishers -> Publication Page (kept intact)
     var pubLink = '<div class="res-publink">' + buildPubLink(sid, rec) + '</div>';
 
-    var dl = [];
-    if (rec && rec.pub_url)   dl.push('<a class="downloadList pdfIcon"  target="_blank" href="' + rec.pub_url + '">PDF</a>');
-    if (rec && rec.gis_data)  dl.push('<a class="downloadList gisIcon"  target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.gis_data + '">GIS data</a>');
-    if (rec && rec.geotiff)   dl.push('<a class="downloadList tiffIcon" target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
-    if (rec && rec.x_section) dl.push('<a class="downloadList xsecIcon res-xsec" href="#" data-xsec="' + rec.x_section + '">Cross-section</a>');
-    if (rec && rec.lith_col)  dl.push('<a class="downloadList xsecIcon res-litho" href="#" data-litho="' + rec.lith_col + '">Lithologic column</a>');
-    if (rec && rec.bsurl)     dl.push('<a class="downloadList purIcon" target="_blank" href="https://utahmapstore.com/products/' + sid + '">Purchase</a>');
-    var downloads = dl.length
-        ? '<div class="res-downloads">' + dl.join('') + '</div>'
-        : '<div class="res-empty">No downloads available for this map.</div>';
+    // consistent resource set: every map shows all six types so layouts match and "grayed" reads as
+    // "this map doesn't have it" (not "broken"). href = external download/link; img = in-app viewer.
+    var items = [
+        { icon: 'pdfIcon',  label: 'PDF',               href: (rec && rec.pub_url)   ? rec.pub_url : '' },
+        { icon: 'gisIcon',  label: 'GIS data',          href: (rec && rec.gis_data)  ? base + rec.gis_data : '' },
+        { icon: 'tiffIcon', label: 'GeoTIFF',           href: (rec && rec.geotiff)   ? base + rec.geotiff : '' },
+        { icon: 'xsecIcon', label: 'Cross-section',     img:  (rec && rec.x_section) ? base + rec.x_section : '' },
+        { icon: 'xsecIcon', label: 'Lithologic column', img:  (rec && rec.lith_col)  ? base + rec.lith_col : '' },
+        { icon: 'purIcon',  label: 'Purchase',          href: (rec && rec.bsurl)     ? 'https://utahmapstore.com/products/' + sid : '' }
+    ];
+    var chips = items.map(function (it) {
+        if (it.href) return '<a class="res-chip ' + it.icon + '" target="_blank" rel="noopener" href="' + it.href + '">' + it.label + '</a>';
+        if (it.img)  return '<a class="res-chip ' + it.icon + ' res-img" href="#" data-img="' + it.img + '">' + it.label + '</a>';
+        return '<span class="res-chip res-chip-off ' + it.icon + '" title="Not available for this map">' + it.label + '</span>';
+    }).join('');
 
     var citeText = rec ? buildCitation(rec) : '';
     var cite = citeText
@@ -2132,11 +2139,11 @@ function renderResources(rec, atts) {
           '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
         : '';
 
-    var prevUrl = (rec && rec.pub_preview) ? ('https://ugspub.nr.utah.gov/publications/mappreviews/' + rec.pub_preview)
-                : (rec && rec.pub_thumb)   ? ('https://ugspub.nr.utah.gov/publications/mapthumbs/' + rec.pub_thumb)
+    var prevUrl = (rec && rec.pub_preview) ? (base + 'mappreviews/' + rec.pub_preview)
+                : (rec && rec.pub_thumb)   ? (base + 'mapthumbs/' + rec.pub_thumb)
                 : '';
     var previewBtn = prevUrl
-        ? '<button type="button" class="res-tool res-preview" data-prev="' + prevUrl + '" title="Open the map preview image">Preview</button>'
+        ? '<button type="button" class="res-tool res-img" data-img="' + prevUrl + '" title="Open the map preview image">Preview</button>'
         : '';
     var tools = '<div class="res-tools">' +
         '<button type="button" class="res-tool res-pan"   title="Pan to this map">Pan to</button>' +
@@ -2145,16 +2152,7 @@ function renderResources(rec, atts) {
         previewBtn +
         '</div>';
 
-    var dlOpen = (atts.units === 'True') ? '' : ' open';   // pub-only maps lead with downloads
-    return pubLink +
-        '<div class="readout-group readout-group-dl' + dlOpen + '">' +
-            '<button type="button" class="readout-group-toggle" aria-expanded="' + (dlOpen ? 'true' : 'false') + '">Downloads &amp; citation</button>' +
-            '<div class="readout-group-content">' + downloads + cite + '</div>' +
-        '</div>' +
-        '<div class="readout-group readout-group-tools">' +
-            '<button type="button" class="readout-group-toggle" aria-expanded="false">Map tools</button>' +
-            '<div class="readout-group-content">' + tools + '</div>' +
-        '</div>';
+    return pubLink + '<div class="res-grid">' + chips + '</div>' + cite + tools;
 }
 
 // fill a section's .readout-resources once the (prefetched) getData record resolves
@@ -2376,7 +2374,13 @@ function loadUnitDescription(atts, evt, bodyEl) {
         if (!bodyEl.isConnected) return;   // section replaced by a newer click
         var unit = (results && results.data && results.data[0]) ? results.data[0] : null;
         if (!unit) {
-            bodyEl.innerHTML = '<div class="unit-desc-text">No geologic unit was found at this location.</div>';
+            // no unit polygon under the click, but the map still has downloads/citation -- show them
+            bodyEl.innerHTML =
+                '<div class="readout-section-body">' +
+                    '<div class="readout-main"><div class="unit-desc-text">No geologic unit was mapped at this exact point. The map&#8217;s resources are below.</div></div>' +
+                    '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+                '</div>';
+            fillResources(atts, bodyEl.querySelector('.readout-resources'));
             return;
         }
         var desc = unit.unit_description;
@@ -2396,7 +2400,14 @@ function loadUnitDescription(atts, evt, bodyEl) {
         var smBtn = bodyEl.querySelector('.readout-show-more');
         if (dtxt && smBtn && dtxt.scrollHeight <= dtxt.clientHeight + 2) smBtn.style.display = 'none';
     }).catch(function (err) {
-        if (bodyEl.isConnected) bodyEl.innerHTML = '<div class="unit-desc-text">Could not load the unit description.</div>';
+        if (bodyEl.isConnected) {
+            bodyEl.innerHTML =
+                '<div class="readout-section-body">' +
+                    '<div class="readout-main"><div class="unit-desc-text">Could not load the unit description. The map&#8217;s resources are below.</div></div>' +
+                    '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+                '</div>';
+            fillResources(atts, bodyEl.querySelector('.readout-resources'));
+        }
         console.error('unit description fetch failed for ' + atts.series_id + ':', err);
     });
 }
@@ -2441,24 +2452,17 @@ $(document).on('click', '#udTab .res-copy', function (e) {
     e.preventDefault();
     copyToClipboard(decodeURIComponent(this.getAttribute('data-cite') || ''));
 });
-// resources: open the cross-section in the existing image viewer
-$(document).on('click', '#udTab .res-xsec', function (e) {
+// resources: open an image (cross-section, lithologic column, or map preview) in the image viewer
+$(document).on('click', '#udTab .res-img', function (e) {
     e.preventDefault();
-    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('.xsection-img').attr('src', this.getAttribute('data-img'));
     $('#xsection-pane').removeClass('hidden');
 });
-// resources: open the lithologic column in the same image viewer
-$(document).on('click', '#udTab .res-litho', function (e) {
-    e.preventDefault();
-    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-litho'));
-    $('#xsection-pane').removeClass('hidden');
+// image viewer: close on Esc or by clicking the image itself, in addition to the X
+$(document).on('keydown', function (e) {
+    if ((e.key === 'Escape' || e.keyCode === 27) && !$('#xsection-pane').hasClass('hidden')) $('#xsection-pane').addClass('hidden');
 });
-// resources: open the map preview image in the same image viewer
-$(document).on('click', '#udTab .res-preview', function (e) {
-    e.preventDefault();
-    $('.xsection-img').attr('src', this.getAttribute('data-prev'));
-    $('#xsection-pane').removeClass('hidden');
-});
+$(document).on('click', '#xsection-pane .xsection-img', function () { $('#xsection-pane').addClass('hidden'); });
 // resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx
 $(document).on('click', '#udTab .res-tool', function (e) {
     e.preventDefault();

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2131,10 +2131,17 @@ function renderResources(rec, atts) {
           '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
         : '';
 
+    var prevUrl = (rec && rec.pub_preview) ? ('https://ugspub.nr.utah.gov/publications/mappreviews/' + rec.pub_preview)
+                : (rec && rec.pub_thumb)   ? ('https://ugspub.nr.utah.gov/publications/mapthumbs/' + rec.pub_thumb)
+                : '';
+    var previewBtn = prevUrl
+        ? '<button type="button" class="res-tool res-preview" data-prev="' + prevUrl + '" title="Open the map preview image">Preview</button>'
+        : '';
     var tools = '<div class="res-tools">' +
         '<button type="button" class="res-tool res-pan"   title="Pan to this map">Pan to</button>' +
         '<button type="button" class="res-tool res-zoom"  title="Zoom to this map">Zoom to</button>' +
         '<button type="button" class="res-tool res-share" title="Copy a shareable link">Copy link</button>' +
+        previewBtn +
         '</div>';
 
     var dlOpen = (atts.units === 'True') ? '' : ' open';   // pub-only maps lead with downloads
@@ -2376,13 +2383,17 @@ function loadUnitDescription(atts, evt, bodyEl) {
         bodyEl.innerHTML =
             '<div class="readout-section-body">' +
                 '<div class="readout-main">' +
-                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
+                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp;' + unit.unit_name + '&nbsp;(' + unit.age + ')</div><hr>' +
                     '<div class="unit-desc-text">' + desc + '</div>' +
                     '<button type="button" class="readout-show-more">Show more</button>' +
                 '</div>' +
                 '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
             '</div>';
         fillResources(atts, bodyEl.querySelector('.readout-resources'));
+        // hide "Show more" when the description isn't actually clamped (short text / no overflow)
+        var dtxt = bodyEl.querySelector('.unit-desc-text');
+        var smBtn = bodyEl.querySelector('.readout-show-more');
+        if (dtxt && smBtn && dtxt.scrollHeight <= dtxt.clientHeight + 2) smBtn.style.display = 'none';
     }).catch(function (err) {
         if (bodyEl.isConnected) bodyEl.innerHTML = '<div class="unit-desc-text">Could not load the unit description.</div>';
         console.error('unit description fetch failed for ' + atts.series_id + ':', err);
@@ -2433,6 +2444,12 @@ $(document).on('click', '#udTab .res-copy', function (e) {
 $(document).on('click', '#udTab .res-xsec', function (e) {
     e.preventDefault();
     $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('#xsection-pane').removeClass('hidden');
+});
+// resources: open the map preview image in the same image viewer
+$(document).on('click', '#udTab .res-preview', function (e) {
+    e.preventDefault();
+    $('.xsection-img').attr('src', this.getAttribute('data-prev'));
     $('#xsection-pane').removeClass('hidden');
 });
 // resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2154,7 +2154,7 @@ function renderResources(rec, atts) {
         previewBtn +
         '</div>';
 
-    return pubLink + '<div class="res-grid">' + chips + '</div>' + cite + tools;
+    return '<div class="res-grid">' + chips + '</div>' + pubLink + cite + tools;
 }
 
 // fill a section's .readout-resources once the (prefetched) getData record resolves
@@ -2170,9 +2170,13 @@ function fillResources(atts, container) {
 function buildPubLink(seriesId, rec) {
     var pub = (rec && rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
     var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
-    return isUgs
-        ? '<a target="_blank" href="https://doi.org/10.34191/' + seriesId + '">DOI Link</a>'
-        : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + seriesId + '">Publication Page</a>';
+    if (isUgs) {
+        // UGS/UGMS: write the DOI out in full (it resolves to our catalog page)
+        var doi = 'https://doi.org/10.34191/' + seriesId;
+        return 'DOI Link: <a target="_blank" rel="noopener" href="' + doi + '">' + doi + '</a>';
+    }
+    // other publishers: we host the catalog page but not their DOI -- a plain hyperlink, not "DOI"
+    return '<a target="_blank" rel="noopener" href="https://geology.utah.gov/publication-details/?pub=' + seriesId + '">Publication Page</a>';
 }
 
 // the functional layer-toggle for a footprint, or null if its category has no working

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2114,12 +2114,12 @@ function buildCitation(rec) {
 // inline resource icons, drawn with currentColor so the chip's text color drives the icon
 // (active = link blue, unavailable = gray). Replaces the faint background-PNG glyphs in the readout.
 var RES_ICONS = {
-    pdf:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M6 2.5h7l5 5V21.5H6z"/><path d="M13 2.5V8h5"/><path d="M9 13h6M9 16.5h6" stroke-width="1.3"/></svg>',
-    gis:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M12 3l9 4.5-9 4.5-9-4.5z"/><path d="M3 12l9 4.5 9-4.5"/><path d="M3 16.5l9 4.5 9-4.5"/></svg>',
-    tiff: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="8.5" cy="10" r="1.6" fill="currentColor" stroke="none"/><path d="M5 17.5l4.5-5 3 3.5L16 11l3.5 6.5"/></svg>',
-    xsec: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 16c3-8 6-8 9 0s6 5 9-3"/><path d="M3 8.5h18"/></svg>',
-    lith: '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="3" width="10" height="4.2" rx="1"/><rect x="7" y="9" width="10" height="5.4" rx="1"/><rect x="7" y="16" width="10" height="5" rx="1"/></svg>',
-    pur:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M3.5 4h2l2.2 10.5h9.3L19 7H7"/><circle cx="10" cy="19.5" r="1.4" fill="currentColor" stroke="none"/><circle cx="17" cy="19.5" r="1.4" fill="currentColor" stroke="none"/></svg>'
+    pdf:  '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M6 2.5h7l5 5V21.5H6z"/><path d="M13 2.5V8h5"/><path d="M9 13h6M9 16.5h6" stroke-width="1.3"/></svg>',
+    gis:  '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M12 3l9 4.5-9 4.5-9-4.5z"/><path d="M3 12l9 4.5 9-4.5"/><path d="M3 16.5l9 4.5 9-4.5"/></svg>',
+    tiff: '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="8.5" cy="10" r="1.6" fill="currentColor" stroke="none"/><path d="M5 17.5l4.5-5 3 3.5L16 11l3.5 6.5"/></svg>',
+    xsec: '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 16c3-8 6-8 9 0s6 5 9-3"/><path d="M3 8.5h18"/></svg>',
+    lith: '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="currentColor"><rect x="7" y="3" width="10" height="4.2" rx="1"/><rect x="7" y="9" width="10" height="5.4" rx="1"/><rect x="7" y="16" width="10" height="5" rx="1"/></svg>',
+    pur:  '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M3.5 4h2l2.2 10.5h9.3L19 7H7"/><circle cx="10" cy="19.5" r="1.4" fill="currentColor" stroke="none"/><circle cx="17" cy="19.5" r="1.4" fill="currentColor" stroke="none"/></svg>'
 };
 
 // the resources block (publication link, downloads, citation, map tools) for one section.
@@ -2141,7 +2141,7 @@ function renderResources(rec, atts) {
         { ic: 'pur',  label: 'Purchase',          href: (rec && rec.bsurl)     ? 'https://utahmapstore.com/products/' + sid : '' }
     ];
     var chips = items.map(function (it) {
-        var icon = RES_ICONS[it.ic];
+        var icon = RES_ICONS[it.ic] || '';
         if (it.href) return '<a class="res-chip" target="_blank" rel="noopener" href="' + it.href + '">' + icon + '<span>' + it.label + '</span></a>';
         if (it.img)  return '<a class="res-chip res-img" href="#" data-img="' + it.img + '">' + icon + '<span>' + it.label + '</span></a>';
         return '<span class="res-chip res-chip-off" title="Not available for this map">' + icon + '<span>' + it.label + '</span></span>';

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2120,6 +2120,7 @@ function renderResources(rec, atts) {
     if (rec && rec.gis_data)  dl.push('<a class="downloadList gisIcon"  target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.gis_data + '">GIS data</a>');
     if (rec && rec.geotiff)   dl.push('<a class="downloadList tiffIcon" target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
     if (rec && rec.x_section) dl.push('<a class="downloadList xsecIcon res-xsec" href="#" data-xsec="' + rec.x_section + '">Cross-section</a>');
+    if (rec && rec.lith_col)  dl.push('<a class="downloadList xsecIcon res-litho" href="#" data-litho="' + rec.lith_col + '">Lithologic column</a>');
     if (rec && rec.bsurl)     dl.push('<a class="downloadList purIcon" target="_blank" href="https://utahmapstore.com/products/' + sid + '">Purchase</a>');
     var downloads = dl.length
         ? '<div class="res-downloads">' + dl.join('') + '</div>'
@@ -2444,6 +2445,12 @@ $(document).on('click', '#udTab .res-copy', function (e) {
 $(document).on('click', '#udTab .res-xsec', function (e) {
     e.preventDefault();
     $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('#xsection-pane').removeClass('hidden');
+});
+// resources: open the lithologic column in the same image viewer
+$(document).on('click', '#udTab .res-litho', function (e) {
+    e.preventDefault();
+    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-litho'));
     $('#xsection-pane').removeClass('hidden');
 });
 // resources: open the map preview image in the same image viewer

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2166,7 +2166,7 @@ function renderResources(rec, atts) {
         previewBtn +
         '</div>';
 
-    return '<div class="res-grid">' + chips + '</div>' + pubLink + cite + tools;
+    return '<div class="res-label">Resources</div><div class="res-grid">' + chips + '</div>' + pubLink + cite + tools;
 }
 
 // fill a section's .readout-resources once the (prefetched) getData record resolves
@@ -2407,7 +2407,7 @@ function loadUnitDescription(atts, evt, bodyEl) {
         bodyEl.innerHTML =
             '<div class="readout-section-body">' +
                 '<div class="readout-main">' +
-                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp;' + unit.unit_name + '&nbsp;(' + unit.age + ')</div><hr>' +
+                    '<div class="unit-desc-title"><span class="ud-sym">' + unit.unit_symbol + '</span>:&nbsp;' + unit.unit_name + '&nbsp;<span class="ud-age">(' + unit.age + ')</span></div><hr>' +
                     '<div class="unit-desc-text">' + desc + '</div>' +
                     '<button type="button" class="readout-show-more">Show more</button>' +
                 '</div>' +

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2200,12 +2200,11 @@ function footprintToggle(attrs) {
 }
 
 // build the readout: the clicked map (openIdx) pinned at the top as the answer, then the
-// other maps as a single-open accordion in a scrollable section below. A rock-hammer badge
-// flags maps with full unit descriptions. Each readout lazy-loads and scrolls within its box.
+// other maps as a single-open accordion in a scrollable section below. A "Units" pill (left of
+// the toggle) flags maps with full unit descriptions. Each readout lazy-loads and scrolls within its box.
 function buildAccordion(ftrs, openIdx) {
     var order = [openIdx];
     for (var i = 0; i < ftrs.length; i++) if (i !== openIdx) order.push(i);
-    var HAMMER = '<svg class="desc-badge" viewBox="0 0 24 24" width="12" height="12" aria-hidden="true" focusable="false"><rect x="3" y="5" width="8" height="5" rx="1.2"/><polygon points="10.5,5 19,7.5 10.5,10"/><rect x="6.3" y="9" width="2.5" height="12" rx="1.2" transform="rotate(9 7.5 10)"/></svg>';
     var primaryHtml = '', cardsHtml = '';
     for (var k = 0; k < order.length; k++) {
         var idx = order[k];
@@ -2214,12 +2213,12 @@ function buildAccordion(ftrs, openIdx) {
         var nm = a.quad_name || a.series_id || '';
         var lyrId = footprintToggle(a);
         var on = !!(lyrId && isVisible(sc));
-        var badge = (a.units === 'True' && sc < 500)   // full descriptions, more detailed than 500k
-            ? '<span class="desc-badge-wrap" title="Full unit descriptions available">' + HAMMER + '</span>' : '';
+        var pill = (a.units === 'True' && sc < 500)   // full descriptions, more detailed than 500k
+            ? '<span class="units-pill" title="Full unit descriptions available" aria-label="Full unit descriptions available">Units</span>' : '';
         var yr = parseInt(a.pub_year);
         var sid = displaySeriesId(a.series_id);
         // scale . map name . series id . year -- all in the same title style
-        var title = badge + scaleLabel(sc) + '&nbsp;&middot;&nbsp;' + nm
+        var title = scaleLabel(sc) + '&nbsp;&middot;&nbsp;' + nm
             + (sid ? '&nbsp;&middot;&nbsp;' + sid : '')
             + (yr ? '&nbsp;&middot;&nbsp;' + yr : '');
         var offCls = (lyrId && !on) ? ' layer-off' : '';
@@ -2231,12 +2230,13 @@ function buildAccordion(ftrs, openIdx) {
         var readout = '<div class="map-section-readout" data-idx="' + idx + '"></div>';
         if (k === 0) {
             primaryHtml = '<div class="readout-primary' + offCls + '" data-idx="' + idx + '">' +
-                '<div class="readout-primary-head"><div class="readout-primary-title">' + title + '</div>' + toggle + '</div>' +
+                '<div class="readout-primary-head"><div class="readout-primary-title">' + title + '</div>' + pill + toggle + '</div>' +
                 readout + '</div>';
         } else {
             cardsHtml += '<div class="map-section' + offCls + '" data-idx="' + idx + '">' +
                 '<div class="map-section-header" role="button" tabindex="0" aria-expanded="false">' +
                     '<span class="map-section-title">' + title + '</span>' +
+                    pill +
                     toggle +
                     '<span class="map-section-chevron" aria-hidden="true"></span></div>' +
                 '<div class="map-section-body">' + readout + '</div></div>';

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -1422,7 +1422,7 @@ $(".map-downloads").click(function () {
     toggleMapDl();
 });
 function toggleMapDl(){
-    $("#unitsPane").hide();
+    $("#unitsPane").addClass("hidden");
     ( map.findLayerById('footprints') ) ? map.findLayerById('footprints').visible = true : addFootprints();
     //if ($('#footprints').is(':checked') == false) $('#footprints').click();  // needs to trigger .change event
     document.getElementById("footprints").disabled = false;
@@ -1455,7 +1455,7 @@ $(".geocoder").click(function () {
 //close when clicking x
 $("#fms-close").click(function () {
     //$("#unitsPane").addClass("hidden");
-    $("#unitsPane").hide();
+    $("#unitsPane").addClass("hidden");
     view.graphics.removeAll();
 });
 
@@ -1933,7 +1933,7 @@ view.on("click", function (evt) {
             {
                 html = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;fetching unit description...</div>';
                 byId('udTab').innerHTML = html;
-                $("#unitsPane").show();
+                $("#unitsPane").removeClass("hidden");
                 fetchAttributes(ftrset,evt);
     
             } else if ($(".map-downloads").hasClass("selected"))  // MAP DOWNLOADS
@@ -1950,7 +1950,7 @@ view.on("click", function (evt) {
     .catch((error) => {
         console.log("Acrgis online Server erro. Server said: ", error);
         byId('udTab').innerHTML = "<div>Server is grumpy. We'll tickle his belly and you can try again in a second.</div>";
-        //$("#unitsPane").hide();
+        //$("#unitsPane").addClass("hidden");
     });
 });    
 */
@@ -2025,7 +2025,7 @@ function queryUnits(evt){
         {
             html = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;fetching unit description...</div>';
             byId('udTab').innerHTML = html;
-            $("#unitsPane").show();
+            $("#unitsPane").removeClass("hidden");
             fetchAttributes(ftrset,evt);
 
         } 
@@ -2033,7 +2033,7 @@ function queryUnits(evt){
     .catch(function (error) {
     //console.log("Acrgis online Server erro. Server said: ", error);
     byId('udTab').innerHTML = "<div>Server is grumpy. We'll tickle his belly and you can try again in a second.</div>";
-    //$("#unitsPane").hide();
+    //$("#unitsPane").addClass("hidden");
     }); 
 }
 
@@ -2061,7 +2061,7 @@ function printMSFms(sdata)
 {
     // redo this .append the right way.
 	$.each(sdata.mapData, function(i, sdx) {
-       $("#unitsPane").show();
+       $("#unitsPane").removeClass("hidden");
 
        var unidesc = '<div>' + '<div class="unit-desc-title">' + sdx.name + '</div><div class="unit-age">(' + sdx.age + ')</div>' + '<hr>' + 
             '<div class="unit-desc-text">' + sdx.descrip + '</div>' + 
@@ -2091,6 +2091,80 @@ function displaySeriesId(id) {
     if (!id) return '';
     if (id === 'Q-2thru5') return 'Q2-Q5';
     return id;
+}
+
+// citation string for a publication record (shared by the readout + the downloads carousel).
+// pub_sec_author is free text that may already contain "and" + multiple names (e.g.
+// "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't already have one.
+function buildCitation(rec) {
+    if (!rec) return '';
+    var authors = rec.pub_author || '';
+    if (rec.pub_sec_author) {
+        var sec = String(rec.pub_sec_author).trim();
+        if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
+    }
+    var scaleInt = rec.pub_scale ? scaleToInt(rec.pub_scale) : '';
+    var publisher = rec.pub_publisher ? rec.pub_publisher : '';
+    var scaleClause = scaleInt ? ('. 1:' + scaleInt + ',000 scale.') : '.';
+    return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + scaleClause;
+}
+
+// the resources block (publication link, downloads, citation, map tools) for one section.
+// rec is the getData record (may be null while loading / if the map has no record).
+function renderResources(rec, atts) {
+    var sid = atts.series_id;
+    var pubLink = '<div class="res-publink">' + buildPubLink(sid, rec) + '</div>';
+
+    var dl = [];
+    if (rec && rec.pub_url)   dl.push('<a class="downloadList pdfIcon"  target="_blank" href="' + rec.pub_url + '">PDF</a>');
+    if (rec && rec.gis_data)  dl.push('<a class="downloadList gisIcon"  target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.gis_data + '">GIS data</a>');
+    if (rec && rec.geotiff)   dl.push('<a class="downloadList tiffIcon" target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
+    if (rec && rec.x_section) dl.push('<a class="downloadList xsecIcon res-xsec" href="#" data-xsec="' + rec.x_section + '">Cross-section</a>');
+    if (rec && rec.bsurl)     dl.push('<a class="downloadList purIcon" target="_blank" href="https://utahmapstore.com/products/' + sid + '">Purchase</a>');
+    var downloads = dl.length
+        ? '<div class="res-downloads">' + dl.join('') + '</div>'
+        : '<div class="res-empty">No downloads available for this map.</div>';
+
+    var citeText = rec ? buildCitation(rec) : '';
+    var cite = citeText
+        ? '<div class="res-cite"><span class="res-cite-text">' + citeText + '</span>' +
+          '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
+        : '';
+
+    var tools = '<div class="res-tools">' +
+        '<button type="button" class="res-tool res-pan"   title="Pan to this map">Pan to</button>' +
+        '<button type="button" class="res-tool res-zoom"  title="Zoom to this map">Zoom to</button>' +
+        '<button type="button" class="res-tool res-share" title="Copy a shareable link">Copy link</button>' +
+        '</div>';
+
+    var dlOpen = (atts.units === 'True') ? '' : ' open';   // pub-only maps lead with downloads
+    return pubLink +
+        '<div class="readout-group readout-group-dl' + dlOpen + '">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="' + (dlOpen ? 'true' : 'false') + '">Downloads &amp; citation</button>' +
+            '<div class="readout-group-content">' + downloads + cite + '</div>' +
+        '</div>' +
+        '<div class="readout-group readout-group-tools">' +
+            '<button type="button" class="readout-group-toggle" aria-expanded="false">Map tools</button>' +
+            '<div class="readout-group-content">' + tools + '</div>' +
+        '</div>';
+}
+
+// fill a section's .readout-resources once the (prefetched) getData record resolves
+function fillResources(atts, container) {
+    if (!container) return;
+    getPubData(atts.series_id)
+        .then(function (rec) { if (container.isConnected) container.innerHTML = renderResources(rec, atts); })
+        .catch(function () { if (container.isConnected) container.innerHTML = renderResources(null, atts); });
+}
+
+// publisher-aware publication link: UGS/UGMS -> our DOI; other publishers -> the UGS catalog
+// page (we host the page but not their DOI, so it must not be labeled a DOI link).
+function buildPubLink(seriesId, rec) {
+    var pub = (rec && rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
+    var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
+    return isUgs
+        ? '<a target="_blank" href="https://doi.org/10.34191/' + seriesId + '">DOI Link</a>'
+        : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + seriesId + '">Publication Page</a>';
 }
 
 // the functional layer-toggle for a footprint, or null if its category has no working
@@ -2300,9 +2374,15 @@ function loadUnitDescription(atts, evt, bodyEl) {
         var desc = unit.unit_description;
         if (scale === '500k') desc = "Only unit symbol and unit name are available at the statewide 1:500,000 scale.";
         bodyEl.innerHTML =
-            '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
-            '<div class="unit-desc-text">' + desc + '</div>' +
-            '<div class="unit-desc-ref">&bull;<a target="_blank" href="https://doi.org/10.34191/' + atts.series_id + '">DOI Link</a></div>';
+            '<div class="readout-section-body">' +
+                '<div class="readout-main">' +
+                    '<div class="unit-desc-title">' + unit.unit_symbol + ':&nbsp' + unit.unit_name + '&nbsp(' + unit.age + ')</div><hr>' +
+                    '<div class="unit-desc-text">' + desc + '</div>' +
+                    '<button type="button" class="readout-show-more">Show more</button>' +
+                '</div>' +
+                '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+            '</div>';
+        fillResources(atts, bodyEl.querySelector('.readout-resources'));
     }).catch(function (err) {
         if (bodyEl.isConnected) bodyEl.innerHTML = '<div class="unit-desc-text">Could not load the unit description.</div>';
         console.error('unit description fetch failed for ' + atts.series_id + ':', err);
@@ -2319,10 +2399,7 @@ function getPubData(seriesId) {
     var url = projectName + '/getData?mapid=' + encodeURIComponent(seriesId);
     var p = fetch(url)
         .then(function (r) { if (!r.ok) throw new Error('getData ' + r.status); return r.json(); })
-        .then(function (data) {
-            var rec = (data && data[0]) ? data[0] : null;
-            return rec ? { pub_url: rec.pub_url, geotiff: rec.geotiff, pub_publisher: rec.pub_publisher } : null;
-        });
+        .then(function (data) { return (data && data[0]) ? data[0] : null; });
     p.catch(function () { delete pubDataCache[seriesId]; });
     pubDataCache[seriesId] = p;
     return p;
@@ -2332,39 +2409,64 @@ function getPubData(seriesId) {
 // their links are already loaded by the time the user opens that section (item: faster links)
 function prefetchPubData(ftrs) {
     for (var i = 0; i < ftrs.length; i++) {
-        var a = ftrs[i].attributes;
-        if (a.units !== 'True' && a.series_id) getPubData(a.series_id).catch(function () {});
+        var sid = ftrs[i].attributes.series_id;
+        if (sid) getPubData(sid).catch(function () {});
     }
 }
 
-// load a units=False map's publication links into the given section body
+// load a units=False map's publication-only section (no unit description)
 function loadPublicationOnly(atts, bodyEl) {
-    var sid = atts.series_id;
-    function paint(rec) {
-        if (!bodyEl.isConnected) return;
-        var links = [];
-        // the publisher decides both the label and the URL, so only emit the catalog link
-        // once we have the record (rec is null on the first, pre-fetch paint).
-        if (rec) {
-            var pub = (rec.pub_publisher ? rec.pub_publisher : '').trim().toUpperCase();
-            var isUgs = (pub === 'UGS' || pub === 'UGMS' || pub.indexOf('UTAH GEOLOGICAL') > -1);
-            // UGS/UGMS: link our DOI (we are the registrant). Maps published by others
-            // (e.g. USGS): we host a catalog page but not their DOI, so link the UGS
-            // publication page and don't call it a DOI link.
-            links.push(isUgs
-                ? '<a target="_blank" href="https://doi.org/10.34191/' + sid + '">DOI Link</a>'
-                : '<a target="_blank" href="https://geology.utah.gov/publication-details/?pub=' + sid + '">Publication Page</a>');
-            if (rec.pub_url) links.push('<a target="_blank" href="' + rec.pub_url + '">PDF</a>');
-            if (rec.geotiff) links.push('<a target="_blank" href="https://ugspub.nr.utah.gov/publications/' + rec.geotiff + '">GeoTIFF</a>');
-        }
-        var linkHtml = links.length ? ('<div class="unit-desc-ref">' + links.join('&nbsp;&middot;&nbsp;') + '</div>') : '';
-        bodyEl.innerHTML = '<div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div>' + linkHtml;
-    }
-    paint(null);
-    getPubData(sid).then(paint).catch(function (err) {
-        console.error('getPubData failed for ' + sid + ':', err);
-    });
+    bodyEl.innerHTML =
+        '<div class="readout-section-body readout-pubonly">' +
+            '<div class="readout-main"><div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div></div>' +
+            '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
+        '</div>';
+    fillResources(atts, bodyEl.querySelector('.readout-resources'));
 }
+
+// resources: copy citation
+$(document).on('click', '#udTab .res-copy', function (e) {
+    e.preventDefault();
+    copyToClipboard(decodeURIComponent(this.getAttribute('data-cite') || ''));
+});
+// resources: open the cross-section in the existing image viewer
+$(document).on('click', '#udTab .res-xsec', function (e) {
+    e.preventDefault();
+    $('.xsection-img').attr('src', 'https://ugspub.nr.utah.gov/publications/' + this.getAttribute('data-xsec'));
+    $('#xsection-pane').removeClass('hidden');
+});
+// resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx
+$(document).on('click', '#udTab .res-tool', function (e) {
+    e.preventDefault();
+    var host = this.closest('[data-idx]');
+    if (!host) return;
+    var ftr = accordionFtrs[parseInt(host.getAttribute('data-idx'), 10)];
+    if (!ftr || !ftr.geometry) return;
+    var ext = ftr.geometry.extent;
+    if (this.classList.contains('res-pan') && ext) {
+        view.center = ext.center;
+    } else if (this.classList.contains('res-zoom') && ext) {
+        view.extent = ext;
+        view.zoom = view.zoom - 1;
+    } else if (this.classList.contains('res-share')) {
+        var sid = ftr.attributes.series_id;
+        var sc = parseInt(ftr.attributes.scale);
+        var lyrs = (sc <= 24) ? '24k' : (sc < 250) ? '100k' : '500k';
+        var base = window.location.href.split('#')[0].split('?')[0];
+        copyToClipboard(encodeURI(base + '?view=scene&sid=' + sid + '&layers=' + lyrs));
+    }
+});
+
+// resources: toggle a disclosure group (mobile); description show more/less (mobile)
+$(document).on('click', '#udTab .readout-group-toggle', function () {
+    var open = this.parentNode.classList.toggle('open');
+    this.setAttribute('aria-expanded', open ? 'true' : 'false');
+});
+$(document).on('click', '#udTab .readout-show-more', function () {
+    var main = this.closest('.readout-main');
+    if (!main) return;
+    this.textContent = main.classList.toggle('expanded') ? 'Show less' : 'Show more';
+});
 
 // add a default map marker when user clicks map
 // to show where fm chosen is...
@@ -2572,15 +2674,7 @@ var printPubs = function(pubResults){
         $( titleArea ).append( '<p class="mapInfo">'+ info +'</p>' );
         $( titleArea ).append( '<p class="mapScale">'+ scaleInt +'k</p>' );
         var publisher = (arr.pub_publisher) ? arr.pub_publisher : "";
-        // pub_sec_author is free text that may already include "and" + multiple names
-        // (e.g. "L.F. Hintze, and J.H. Madsen Jr."), so only add "and" when it doesn't
-        // already have one -- avoids "Stokes, and Hintze, and Madsen".
-        var authors = arr.pub_author;
-        if (arr.pub_sec_author) {
-            var sec = String(arr.pub_sec_author).trim();
-            if (sec) authors += (/\band\b/i.test(sec) ? ', ' : ', and ') + sec;
-        }
-        var reftxt = authors +', '+ arr.pub_year +', '+ arr.pub_name +'. '+ arr.series_id +'. '+ publisher +'. 1:'+ scaleInt +',000 scale.';
+        var reftxt = buildCitation(arr);
         var copydiv = $('<p class="mapRef smallscroll tooltip ref-right" data-title="click to copy map reference"><span id="copyRef" data-title="copy reference" title="copy reference to clip board" class="esri-icon-duplicate"></span>&nbsp;'+ reftxt +'</p><br><br>');
         copydiv.click(function(n) {
             //console.log('copy to clipboard');

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2440,7 +2440,7 @@ function prefetchPubData(ftrs) {
 // load a units=False map's publication-only section (no unit description)
 function loadPublicationOnly(atts, bodyEl) {
     bodyEl.innerHTML =
-        '<div class="readout-section-body readout-pubonly">' +
+        '<div class="readout-section-body">' +
             '<div class="readout-main"><div class="unit-desc-text">Tabular GIS data has not been generated for this map; see the publication.</div></div>' +
             '<div class="readout-resources"><img height="14" src="images/loading.gif" alt="">&nbsp;loading&#8230;</div>' +
         '</div>';
@@ -2485,11 +2485,7 @@ $(document).on('click', '#udTab .res-tool', function (e) {
     }
 });
 
-// resources: toggle a disclosure group (mobile); description show more/less (mobile)
-$(document).on('click', '#udTab .readout-group-toggle', function () {
-    var open = this.parentNode.classList.toggle('open');
-    this.setAttribute('aria-expanded', open ? 'true' : 'false');
-});
+// description show more/less
 $(document).on('click', '#udTab .readout-show-more', function () {
     var main = this.closest('.readout-main');
     if (!main) return;

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -1115,6 +1115,8 @@ $("#unitsPane").on("change", ".section-layer-toggle", function () {
     var sec = this.closest('.map-section, .readout-primary');
     if (sec) sec.classList.toggle('layer-off', !this.checked);
 });
+// clicking/keying the in-header layer toggle must not also expand/collapse the section
+$("#unitsPane").on("click keydown", ".layer-switch", function (e) { e.stopPropagation(); });
 // keyboard: Enter/Space on a section header opens/closes it (header is role=button tabindex=0)
 $("#unitsPane").on("keydown", ".map-section-header", function (e) {
     if (e.key === "Enter" || e.key === " " || e.keyCode === 13 || e.keyCode === 32) {
@@ -2136,7 +2138,7 @@ function renderResources(rec, atts) {
     var citeText = rec ? buildCitation(rec) : '';
     var cite = citeText
         ? '<div class="res-cite"><span class="res-cite-text">' + citeText + '</span>' +
-          '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation">&#x2398;</button></div>'
+          '<button type="button" class="res-copy" data-cite="' + encodeURIComponent(citeText) + '" title="Copy citation"><span class="esri-icon-duplicate" aria-hidden="true"></span>Copy</button></div>'
         : '';
 
     var prevUrl = (rec && rec.pub_preview) ? (base + 'mappreviews/' + rec.pub_preview)
@@ -2219,8 +2221,9 @@ function buildAccordion(ftrs, openIdx) {
             cardsHtml += '<div class="map-section' + offCls + '" data-idx="' + idx + '">' +
                 '<div class="map-section-header" role="button" tabindex="0" aria-expanded="false">' +
                     '<span class="map-section-title">' + title + '</span>' +
+                    toggle +
                     '<span class="map-section-chevron" aria-hidden="true"></span></div>' +
-                '<div class="map-section-body">' + readout + toggle + '</div></div>';
+                '<div class="map-section-body">' + readout + '</div></div>';
         }
     }
     var others = cardsHtml ? '<div class="readout-others"><div class="other-maps-label">Other maps at this location</div>' + cardsHtml + '</div>' : '';
@@ -2458,11 +2461,14 @@ $(document).on('click', '#udTab .res-img', function (e) {
     $('.xsection-img').attr('src', this.getAttribute('data-img'));
     $('#xsection-pane').removeClass('hidden');
 });
-// image viewer: close on Esc or by clicking the image itself, in addition to the X
+// image viewer: close on Esc, or on any click except the chip that (re)opens it (click anywhere closes)
 $(document).on('keydown', function (e) {
     if ((e.key === 'Escape' || e.keyCode === 27) && !$('#xsection-pane').hasClass('hidden')) $('#xsection-pane').addClass('hidden');
 });
-$(document).on('click', '#xsection-pane .xsection-img', function () { $('#xsection-pane').addClass('hidden'); });
+$(document).on('click', function (e) {
+    var pane = document.getElementById('xsection-pane');
+    if (pane && !pane.classList.contains('hidden') && !(e.target.closest && e.target.closest('.res-img'))) pane.classList.add('hidden');
+});
 // resources: pan / zoom / share, keyed to the section's footprint via the nearest data-idx
 $(document).on('click', '#udTab .res-tool', function (e) {
     e.preventDefault();

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -2111,6 +2111,17 @@ function buildCitation(rec) {
     return authors + ', ' + rec.pub_year + ', ' + rec.pub_name + '. ' + rec.series_id + '. ' + publisher + scaleClause;
 }
 
+// inline resource icons, drawn with currentColor so the chip's text color drives the icon
+// (active = link blue, unavailable = gray). Replaces the faint background-PNG glyphs in the readout.
+var RES_ICONS = {
+    pdf:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M6 2.5h7l5 5V21.5H6z"/><path d="M13 2.5V8h5"/><path d="M9 13h6M9 16.5h6" stroke-width="1.3"/></svg>',
+    gis:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M12 3l9 4.5-9 4.5-9-4.5z"/><path d="M3 12l9 4.5 9-4.5"/><path d="M3 16.5l9 4.5 9-4.5"/></svg>',
+    tiff: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="8.5" cy="10" r="1.6" fill="currentColor" stroke="none"/><path d="M5 17.5l4.5-5 3 3.5L16 11l3.5 6.5"/></svg>',
+    xsec: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 16c3-8 6-8 9 0s6 5 9-3"/><path d="M3 8.5h18"/></svg>',
+    lith: '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="3" width="10" height="4.2" rx="1"/><rect x="7" y="9" width="10" height="5.4" rx="1"/><rect x="7" y="16" width="10" height="5" rx="1"/></svg>',
+    pur:  '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M3.5 4h2l2.2 10.5h9.3L19 7H7"/><circle cx="10" cy="19.5" r="1.4" fill="currentColor" stroke="none"/><circle cx="17" cy="19.5" r="1.4" fill="currentColor" stroke="none"/></svg>'
+};
+
 // the resources block (publication link, downloads, citation, map tools) for one section.
 // rec is the getData record (may be null while loading / if the map has no record).
 function renderResources(rec, atts) {
@@ -2122,17 +2133,18 @@ function renderResources(rec, atts) {
     // consistent resource set: every map shows all six types so layouts match and "grayed" reads as
     // "this map doesn't have it" (not "broken"). href = external download/link; img = in-app viewer.
     var items = [
-        { icon: 'pdfIcon',  label: 'PDF',               href: (rec && rec.pub_url)   ? rec.pub_url : '' },
-        { icon: 'gisIcon',  label: 'GIS data',          href: (rec && rec.gis_data)  ? base + rec.gis_data : '' },
-        { icon: 'tiffIcon', label: 'GeoTIFF',           href: (rec && rec.geotiff)   ? base + rec.geotiff : '' },
-        { icon: 'xsecIcon', label: 'Cross-section',     img:  (rec && rec.x_section) ? base + rec.x_section : '' },
-        { icon: 'xsecIcon', label: 'Lithologic column', img:  (rec && rec.lith_col)  ? base + rec.lith_col : '' },
-        { icon: 'purIcon',  label: 'Purchase',          href: (rec && rec.bsurl)     ? 'https://utahmapstore.com/products/' + sid : '' }
+        { ic: 'pdf',  label: 'PDF',               href: (rec && rec.pub_url)   ? rec.pub_url : '' },
+        { ic: 'gis',  label: 'GIS data',          href: (rec && rec.gis_data)  ? base + rec.gis_data : '' },
+        { ic: 'tiff', label: 'GeoTIFF',           href: (rec && rec.geotiff)   ? base + rec.geotiff : '' },
+        { ic: 'xsec', label: 'Cross-section',     img:  (rec && rec.x_section) ? base + rec.x_section : '' },
+        { ic: 'lith', label: 'Lithologic column', img:  (rec && rec.lith_col)  ? base + rec.lith_col : '' },
+        { ic: 'pur',  label: 'Purchase',          href: (rec && rec.bsurl)     ? 'https://utahmapstore.com/products/' + sid : '' }
     ];
     var chips = items.map(function (it) {
-        if (it.href) return '<a class="res-chip ' + it.icon + '" target="_blank" rel="noopener" href="' + it.href + '">' + it.label + '</a>';
-        if (it.img)  return '<a class="res-chip ' + it.icon + ' res-img" href="#" data-img="' + it.img + '">' + it.label + '</a>';
-        return '<span class="res-chip res-chip-off ' + it.icon + '" title="Not available for this map">' + it.label + '</span>';
+        var icon = RES_ICONS[it.ic];
+        if (it.href) return '<a class="res-chip" target="_blank" rel="noopener" href="' + it.href + '">' + icon + '<span>' + it.label + '</span></a>';
+        if (it.img)  return '<a class="res-chip res-img" href="#" data-img="' + it.img + '">' + icon + '<span>' + it.label + '</span></a>';
+        return '<span class="res-chip res-chip-off" title="Not available for this map">' + icon + '<span>' + it.label + '</span></span>';
     }).join('');
 
     var citeText = rec ? buildCitation(rec) : '';

--- a/public/style.css
+++ b/public/style.css
@@ -2203,10 +2203,14 @@ p:last-child {
 
 /* consistent resource grid: all six types on every map; unavailable ones grayed + tooltipped */
 .res-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 5px 12px; margin: 6px 0; }
-.res-chip { font-size: 12px; line-height: 24px; min-height: 24px; display: flex; align-items: center; color: #326A98; text-decoration: none; background-repeat: no-repeat; background-position: left center; background-size: 22px 22px; padding-left: 28px; }
-.res-chip:hover { color: #1d4e78; text-decoration: underline; }
-.res-chip-off { color: #8a8a8a; cursor: not-allowed; filter: grayscale(1); opacity: 0.8; }
-.res-chip-off:hover { color: #b6b6b6; text-decoration: none; }
+.res-chip { font-size: 12.5px; min-height: 24px; display: flex; align-items: center; gap: 8px; color: #326A98; text-decoration: none; }
+.res-chip svg { flex: none; }
+.res-chip span { min-width: 0; overflow-wrap: anywhere; }
+.res-chip:hover { color: #1d4e78; }
+.res-chip:hover span { text-decoration: underline; }
+.res-chip-off { color: #8d8d8d; cursor: not-allowed; }
+.res-chip-off:hover { color: #8d8d8d; }
+.res-chip-off:hover span { text-decoration: none; }
 
 .res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 10px; font-size: 11px; line-height: 14px; color: #555; }
 .res-cite-text { flex: 1; overflow-wrap: anywhere; }

--- a/public/style.css
+++ b/public/style.css
@@ -2143,8 +2143,8 @@ p:last-child {
 .readout-primary { padding: 0 2px; }
 /* pin the clicked-map title to the top of the scroll area; right-padding clears the absolutely
    positioned close button (#fms-close, z-index 10), which stays above this (z-index 1) and clickable */
-.readout-primary-head { position: sticky; top: 0; z-index: 1; background: #fff; padding: 0 28px 6px 0; border-bottom: 1px solid #eee; margin-bottom: 6px; }
-.readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
+.readout-primary-head { position: sticky; top: 0; z-index: 1; display: flex; align-items: center; gap: 10px; background: #fff; padding: 0 28px 6px 0; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+.readout-primary-title { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
 
 /* the other maps, listed below the primary */
 .readout-others { border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
@@ -2175,6 +2175,8 @@ p:last-child {
 .layer-switch input:checked + .layer-switch-slider { background: #6396fc; }
 .layer-switch input:checked + .layer-switch-slider::after { transform: translateX(13px); }
 .layer-switch input:focus-visible + .layer-switch-slider { outline: 2px solid #6396fc; outline-offset: 2px; }
+/* in a section header (title row), the toggle sits inline on the right -- drop the stacked margin */
+.readout-primary-head .layer-switch, .map-section-header .layer-switch { margin-top: 0; flex: none; }
 
 /* rock-hammer badge: full unit descriptions available for this map */
 .desc-badge-wrap { display: inline-flex; vertical-align: middle; margin-right: 4px; position: relative; top: -1px; }
@@ -2208,7 +2210,9 @@ p:last-child {
 
 .res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 10px; font-size: 11px; line-height: 14px; color: #555; }
 .res-cite-text { flex: 1; overflow-wrap: anywhere; }
-.res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
+.res-copy { flex: none; display: inline-flex; align-items: center; gap: 4px; border: 1px solid #d4dde7; background: #f5f6f8; border-radius: 4px; cursor: pointer; color: #326A98; font-size: 11px; padding: 2px 8px; line-height: 1.5; }
+.res-copy:hover { background: #eceff4; }
+.res-copy .esri-icon-duplicate { font-size: 13px; }
 
 .res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
 .res-tool { font-size: 11px; padding: 4px 9px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }

--- a/public/style.css
+++ b/public/style.css
@@ -2141,7 +2141,9 @@ p:last-child {
 
 /* primary = the clicked map, open on top */
 .readout-primary { padding: 0 2px; }
-.readout-primary-head { padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+/* pin the clicked-map title to the top of the scroll area; right-padding clears the absolutely
+   positioned close button (#fms-close, z-index 10), which stays above this (z-index 1) and clickable */
+.readout-primary-head { position: sticky; top: 0; z-index: 1; background: #fff; padding: 0 28px 6px 0; border-bottom: 1px solid #eee; margin-bottom: 6px; }
 .readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
 
 /* the other maps, listed below the primary */

--- a/public/style.css
+++ b/public/style.css
@@ -799,19 +799,7 @@ overflow-y: hidden;
     background-image: url(images/comment.png);
 }
 
-/* bottom right corner of map */
-.ugs-watermark {
-    position: absolute;
-    bottom: 20px;
-    right: 20px;
-    height: 42px;
-    width: 128px;
-    z-index: 5;
-    cursor: pointer;
-    background-image: url(images/ugs-logo.png);
-    background-repeat: no-repeat;
-    opacity: 1;
-}
+/* ugs-watermark removed: the readout panel now occupies the map's bottom-right corner */
 
 
 /* 
@@ -2199,14 +2187,17 @@ p:last-child {
 /* consolidated section: stacked by default; two columns on desktop (media query below) */
 .readout-section-body { display: block; }
 .readout-main, .readout-resources { min-width: 0; }
+.readout-main hr { border: 0; border-top: 1px solid #eee; margin: 4px 0; }
 
 .res-publink { font-size: 11px; margin: 4px 0; }
-.res-downloads { display: flex; flex-direction: column; gap: 3px; margin: 4px 0; }
-.res-downloads .downloadList { font-size: 12px; line-height: 18px; }
+.res-publink a { overflow-wrap: anywhere; }
+.res-downloads { display: flex; flex-direction: column; gap: 6px; margin: 6px 0; }
+.res-downloads .downloadList { font-family: "Avenir Next W00", Helvetica, Arial, sans-serif; font-size: 12px; line-height: 20px; min-height: 20px; color: #326A98; background-size: 18px 18px; padding-left: 24px; display: flex; align-items: center; }
+.res-downloads .downloadList:hover { color: #1d4e78; text-decoration: underline; }
 .res-empty { font-size: 11px; color: #9a9a9a; margin: 4px 0; }
 
-.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 10px; line-height: 13px; color: #555; }
-.res-cite-text { flex: 1; }
+.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 11px; line-height: 14px; color: #555; }
+.res-cite-text { flex: 1; overflow-wrap: anywhere; }
 .res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
 
 .res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
@@ -2224,11 +2215,18 @@ p:last-child {
 .readout-show-more { display: none; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
 
 @media (min-width: 768px) {
-    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(165px, 1fr); gap: 12px; }
+    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(180px, 1fr); gap: 0; align-items: start; }
     .readout-section-body.readout-pubonly { grid-template-columns: 1fr; }
+    /* quiet hairline so the resources read as a distinct rail, not part of the description */
+    .readout-resources { border-left: 1px solid #ececec; padding-left: 12px; }
+    .readout-section-body.readout-pubonly .readout-resources { border-left: 0; padding-left: 0; }
     .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
     .readout-group-content { display: block; }
     .readout-group { margin-top: 10px; }
+    /* bound a long description so it doesn't dwarf the rail; "Show more" expands it in place */
+    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 11; -webkit-box-orient: vertical; overflow: hidden; }
+    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
+    .readout-show-more { display: inline-block; }
 }
 
 @media (max-width: 767px) {

--- a/public/style.css
+++ b/public/style.css
@@ -2158,7 +2158,7 @@ p:last-child {
 .map-section-header { display: flex; align-items: center; gap: 8px; padding: 7px 9px; cursor: pointer; }
 .map-section-header:focus { outline: 2px solid #6396fc; outline-offset: -2px; }
 .map-section-header:focus:not(:focus-visible) { outline: none; }
-.map-section-title { flex: 1; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 14px; letter-spacing: .3px; line-height: 1.15; color: #4a4a4a; overflow-wrap: anywhere; }
+.map-section-title { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 14px; letter-spacing: .3px; line-height: 1.15; color: #4a4a4a; overflow-wrap: anywhere; }
 .map-section.open .map-section-title { color: #326A98; }
 
 /* pure-css chevron */
@@ -2179,14 +2179,13 @@ p:last-child {
 /* in a section header (title row), the toggle sits inline on the right -- drop the stacked margin */
 .readout-primary-head .layer-switch, .map-section-header .layer-switch { margin-top: 0; flex: none; }
 
-/* rock-hammer badge: full unit descriptions available for this map */
-.desc-badge-wrap { display: inline-flex; vertical-align: middle; margin-right: 4px; position: relative; top: -1px; }
-.desc-badge { fill: #326A98; }
+/* "Units" pill: full unit descriptions available for this map (sits left of the toggle) */
+.units-pill { flex: none; font-family: 'Open Sans', sans-serif; font-size: 9px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; color: #fff; background: #326A98; border-radius: 4px; padding: 2px 6px; line-height: 1; -webkit-font-smoothing: antialiased; }
 
 /* gray a map's title when its layer is off (mirrors the layer list) */
 .readout-primary.layer-off .readout-primary-title { color: #a6a6a6; }
 .map-section.layer-off .map-section-title { color: #a6a6a6; }
-.layer-off .desc-badge { fill: #bcbcbc; }
+.layer-off .units-pill { background: #bcbcbc; }
 .map-section.layer-off .map-section-chevron { border-color: #c4c4c4; }
 
 /* consolidated section: single column -- description, then a consistent resource grid */

--- a/public/style.css
+++ b/public/style.css
@@ -2143,8 +2143,9 @@ p:last-child {
 .readout-primary { padding: 0 2px; }
 /* pin the clicked-map title to the top of the scroll area; right-padding clears the absolutely
    positioned close button (#fms-close, z-index 10), which stays above this (z-index 1) and clickable */
-.readout-primary-head { position: sticky; top: 0; z-index: 1; display: flex; align-items: center; gap: 10px; background: #fff; padding: 0 28px 6px 0; border-bottom: 1px solid #eee; margin-bottom: 6px; }
-.readout-primary-title { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
+.readout-primary-head { position: sticky; top: 0; z-index: 1; display: flex; align-items: center; gap: 10px; background: #fff; padding: 0 28px 7px 0; border-bottom: 1px solid #ededed; margin-bottom: 8px; }
+.readout-primary-head::after { content: ""; position: absolute; left: 0; bottom: -1px; width: 54px; height: 2px; background: #326A98; border-radius: 2px; }
+.readout-primary-title { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 18px; letter-spacing: .4px; line-height: 1.08; color: #235c87; overflow-wrap: anywhere; }
 
 /* the other maps, listed below the primary */
 .readout-others { border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
@@ -2192,6 +2193,9 @@ p:last-child {
 .readout-section-body { display: block; }
 .readout-main { min-width: 0; }
 .readout-main hr { border: 0; border-top: 1px solid #eee; margin: 4px 0; }
+.unit-desc-title .ud-sym { color: #326A98; }
+.unit-desc-title .ud-age { font-weight: 400; color: #777; }
+.res-label { margin: 14px 0 6px; font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; }
 /* clamp the description; "Show more" expands it (JS hides the button when it doesn't overflow) */
 .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 10; -webkit-box-orient: vertical; overflow: hidden; }
 .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }

--- a/public/style.css
+++ b/public/style.css
@@ -2186,57 +2186,31 @@ p:last-child {
 .layer-off .desc-badge { fill: #bcbcbc; }
 .map-section.layer-off .map-section-chevron { border-color: #c4c4c4; }
 
-/* consolidated section: stacked by default; two columns on desktop (media query below) */
+/* consolidated section: single column -- description, then a consistent resource grid */
 .readout-section-body { display: block; }
-.readout-main, .readout-resources { min-width: 0; }
+.readout-main { min-width: 0; }
 .readout-main hr { border: 0; border-top: 1px solid #eee; margin: 4px 0; }
+/* clamp the description; "Show more" expands it (JS hides the button when it doesn't overflow) */
+.readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 10; -webkit-box-orient: vertical; overflow: hidden; }
+.readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
+.readout-show-more { display: inline-block; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
 
-.res-publink { font-size: 11px; margin: 4px 0; }
+.readout-resources { margin-top: 6px; }
+.res-publink { font-size: 11.5px; margin: 6px 0; }
 .res-publink a { overflow-wrap: anywhere; }
-.res-downloads { display: flex; flex-direction: column; gap: 6px; margin: 6px 0; }
-.res-downloads .downloadList { font-family: "Avenir Next W00", Helvetica, Arial, sans-serif; font-size: 12px; line-height: 20px; min-height: 20px; color: #326A98; background-size: 18px 18px; padding-left: 24px; display: flex; align-items: center; }
-.res-downloads .downloadList:hover { color: #1d4e78; text-decoration: underline; }
-.res-empty { font-size: 11px; color: #9a9a9a; margin: 4px 0; }
 
-.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 11px; line-height: 14px; color: #555; }
+/* consistent resource grid: all six types on every map; unavailable ones grayed + tooltipped */
+.res-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 5px 12px; margin: 6px 0; }
+.res-chip { font-size: 12px; line-height: 20px; min-height: 20px; display: flex; align-items: center; color: #326A98; text-decoration: none; background-repeat: no-repeat; background-position: left center; background-size: 18px 18px; padding-left: 24px; }
+.res-chip:hover { color: #1d4e78; text-decoration: underline; }
+.res-chip-off { color: #b6b6b6; cursor: not-allowed; filter: grayscale(1); opacity: 0.5; }
+.res-chip-off:hover { color: #b6b6b6; text-decoration: none; }
+
+.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 10px; font-size: 11px; line-height: 14px; color: #555; }
 .res-cite-text { flex: 1; overflow-wrap: anywhere; }
 .res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
 
-.res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
-.res-tool { font-size: 11px; padding: 3px 8px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
+.res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.res-tool { font-size: 11px; padding: 4px 9px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
 .res-tool:hover { background: #eceff4; }
-
-/* disclosure groups: collapsible on mobile, always-open rail on desktop */
-.readout-group { margin-top: 8px; }
-.readout-group-toggle { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; border: none; background: none; padding: 4px 0; cursor: pointer; font: 600 12px "Avenir Next W00", Helvetica, Arial, sans-serif; color: #4a4a4a; }
-.readout-group-toggle::before { content: "\25B8"; font-size: 9px; transition: transform .15s ease; }
-.readout-group.open .readout-group-toggle::before { transform: rotate(90deg); }
-.readout-group-content { display: none; padding-left: 2px; }
-.readout-group.open .readout-group-content { display: block; }
-
-.readout-show-more { display: none; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
-
-@media (min-width: 768px) {
-    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(180px, 1fr); gap: 0; align-items: start; }
-    .readout-section-body.readout-pubonly { grid-template-columns: 1fr; }
-    /* quiet hairline so the resources read as a distinct rail, not part of the description */
-    .readout-resources { border-left: 1px solid #ececec; padding-left: 12px; }
-    .readout-section-body.readout-pubonly .readout-resources { border-left: 0; padding-left: 0; }
-    .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
-    .readout-group-content { display: block; }
-    .readout-group { margin-top: 10px; }
-    /* bound a long description so it doesn't dwarf the rail; "Show more" expands it in place */
-    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 11; -webkit-box-orient: vertical; overflow: hidden; }
-    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
-    .readout-show-more { display: inline-block; }
-}
-
-@media (max-width: 767px) {
-    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
-    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
-    .readout-show-more { display: inline-block; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .readout-group-toggle::before { transition: none; }
-}
+.res-tool:active { background: #e2e7ee; }

--- a/public/style.css
+++ b/public/style.css
@@ -1463,14 +1463,24 @@ p:last-child {
     bottom: 0px;
     right: -5px;
     max-height:75vh;
-    width: 300px;
+    width: 440px;
     z-index: 99;
     border-radius: 6px;
     padding: 8px;
     margin: 5px;
-    overflow-y: auto;
-    opacity: 0.85;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    opacity: 0.96;
     background-color: white;
+}
+/* #udTab is the single scroll container; the close button (absolute in #unitsPane) stays pinned */
+#udTab { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+#dlTab { flex: none; }
+#unitsPane.hidden { display: none; }   /* beat the id-specificity of display:flex when hidden */
+
+@media (max-width: 767px) {
+    #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }
 }
 
 .unit-desc-title {
@@ -2135,26 +2145,23 @@ p:last-child {
 
 } /*  end @media for mobile */
 
-/* unit-readout: the clicked map pinned at top as the answer + the other maps as a single-open
-   accordion below. .map-readout is height-bounded so the primary description scrolls in its own
-   box and the "other maps" section stays pinned at the bottom. Its cap is kept strictly inside
-   #unitsPane (max-height:75vh) minus that pane's 16px padding (plus a buffer), so #unitsPane
-   itself never has to scroll the accordion and the bottom section can't be clipped -- including
-   at high browser zoom, where the fixed padding used to overrun the old, too-close 72vh/75%. */
-.map-readout { display: flex; flex-direction: column; max-height: calc(75vh - 30px); font-size: 13px; }
+/* unit-readout: the clicked map (open primary) on top + the other maps as a single-open
+   accordion below. Sections are compact (progressive disclosure), so the readout flows
+   naturally and #udTab is the single scroll container (see the #udTab / #unitsPane rules) --
+   no nested vh-capped scroll boxes. One scrollbar, and nothing clips at high browser zoom. */
+.map-readout { font-size: 13px; }
 
-/* primary = the clicked map, pinned at the top; its description scrolls within a capped box */
-.readout-primary { flex: 0 1 auto; min-height: 0; display: flex; flex-direction: column; padding: 0 2px; }
-.readout-primary-head { flex: none; padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
+/* primary = the clicked map, open on top */
+.readout-primary { padding: 0 2px; }
+.readout-primary-head { padding-bottom: 6px; border-bottom: 1px solid #eee; margin-bottom: 6px; }
 .readout-primary-title { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 16px; letter-spacing: .3px; line-height: 1.1; color: #326A98; overflow-wrap: anywhere; }
-.readout-primary .map-section-readout { flex: 1 1 auto; min-height: 0; max-height: 45vh; overflow-y: auto; overscroll-behavior: contain; }
 
-/* the other maps, pinned in their own scrollable section below the primary */
-.readout-others { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; overscroll-behavior: contain; border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
-.other-maps-label { flex: none; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
+/* the other maps, listed below the primary */
+.readout-others { border-top: 1px solid #e6e6e6; margin-top: 8px; padding-top: 6px; }
+.other-maps-label { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 0 0 5px; }
 
 /* other-map cards (collapsed headers, single-open) */
-.map-section { flex: none; border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
+.map-section { border: 1px solid #e3e3e3; border-radius: 5px; margin-bottom: 6px; background: #f5f6f8; transition: background .15s ease, box-shadow .15s ease, border-color .15s ease; }
 .map-section:hover { background: #eceff4; }
 .map-section.open { background: #fff; border-color: #d4dde7; box-shadow: 0 1px 5px rgba(50,106,152,.12); }
 .map-section-header { display: flex; align-items: center; gap: 8px; padding: 7px 9px; cursor: pointer; }
@@ -2169,7 +2176,6 @@ p:last-child {
 
 .map-section-body { display: none; padding: 0 10px 9px; }
 .map-section.open .map-section-body { display: block; }
-.map-section.open .map-section-readout { max-height: 30vh; overflow-y: auto; overscroll-behavior: contain; }
 
 /* layer toggle switch (on = accent blue), behaves like a layer-list checkbox */
 .layer-switch { display: inline-flex; align-items: center; gap: 7px; margin-top: 9px; cursor: pointer; font-size: 11px; color: #6a6a6a; user-select: none; }
@@ -2189,3 +2195,48 @@ p:last-child {
 .map-section.layer-off .map-section-title { color: #a6a6a6; }
 .layer-off .desc-badge { fill: #bcbcbc; }
 .map-section.layer-off .map-section-chevron { border-color: #c4c4c4; }
+
+/* consolidated section: stacked by default; two columns on desktop (media query below) */
+.readout-section-body { display: block; }
+.readout-main, .readout-resources { min-width: 0; }
+
+.res-publink { font-size: 11px; margin: 4px 0; }
+.res-downloads { display: flex; flex-direction: column; gap: 3px; margin: 4px 0; }
+.res-downloads .downloadList { font-size: 12px; line-height: 18px; }
+.res-empty { font-size: 11px; color: #9a9a9a; margin: 4px 0; }
+
+.res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 8px; font-size: 10px; line-height: 13px; color: #555; }
+.res-cite-text { flex: 1; }
+.res-copy { flex: none; border: none; background: none; cursor: pointer; color: #326A98; font-size: 14px; line-height: 1; padding: 0; }
+
+.res-tools { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.res-tool { font-size: 11px; padding: 3px 8px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
+.res-tool:hover { background: #eceff4; }
+
+/* disclosure groups: collapsible on mobile, always-open rail on desktop */
+.readout-group { margin-top: 8px; }
+.readout-group-toggle { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; border: none; background: none; padding: 4px 0; cursor: pointer; font: 600 12px "Avenir Next W00", Helvetica, Arial, sans-serif; color: #4a4a4a; }
+.readout-group-toggle::before { content: "\25B8"; font-size: 9px; transition: transform .15s ease; }
+.readout-group.open .readout-group-toggle::before { transform: rotate(90deg); }
+.readout-group-content { display: none; padding-left: 2px; }
+.readout-group.open .readout-group-content { display: block; }
+
+.readout-show-more { display: none; border: none; background: none; color: #326A98; cursor: pointer; font-size: 11px; padding: 2px 0; }
+
+@media (min-width: 768px) {
+    .readout-section-body { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(165px, 1fr); gap: 12px; }
+    .readout-section-body.readout-pubonly { grid-template-columns: 1fr; }
+    .readout-group-toggle { display: none; }      /* desktop = always-visible rail, no toggles */
+    .readout-group-content { display: block; }
+    .readout-group { margin-top: 10px; }
+}
+
+@media (max-width: 767px) {
+    .readout-main .unit-desc-text { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
+    .readout-main.expanded .unit-desc-text { -webkit-line-clamp: unset; overflow: visible; }
+    .readout-show-more { display: inline-block; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .readout-group-toggle::before { transition: none; }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -2203,9 +2203,9 @@ p:last-child {
 
 /* consistent resource grid: all six types on every map; unavailable ones grayed + tooltipped */
 .res-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 5px 12px; margin: 6px 0; }
-.res-chip { font-size: 12px; line-height: 20px; min-height: 20px; display: flex; align-items: center; color: #326A98; text-decoration: none; background-repeat: no-repeat; background-position: left center; background-size: 18px 18px; padding-left: 24px; }
+.res-chip { font-size: 12px; line-height: 24px; min-height: 24px; display: flex; align-items: center; color: #326A98; text-decoration: none; background-repeat: no-repeat; background-position: left center; background-size: 22px 22px; padding-left: 28px; }
 .res-chip:hover { color: #1d4e78; text-decoration: underline; }
-.res-chip-off { color: #b6b6b6; cursor: not-allowed; filter: grayscale(1); opacity: 0.5; }
+.res-chip-off { color: #8a8a8a; cursor: not-allowed; filter: grayscale(1); opacity: 0.8; }
 .res-chip-off:hover { color: #b6b6b6; text-decoration: none; }
 
 .res-cite { display: flex; align-items: flex-start; gap: 6px; margin-top: 10px; font-size: 11px; line-height: 14px; color: #555; }

--- a/public/style.css
+++ b/public/style.css
@@ -1451,7 +1451,7 @@ p:last-child {
     bottom: 0px;
     right: -5px;
     max-height:75vh;
-    width: 440px;
+    width: 500px;
     z-index: 99;
     border-radius: 6px;
     padding: 8px;


### PR DESCRIPTION
## Summary
The approved **"Refined Light"** visual polish of the consolidated readout — crisp inline-SVG resource icons, a deeper-blue header with an accent bar, an accented unit symbol, a "Resources" label, and a visible-but-muted grayed state. **Look-and-feel only**, no behavioral change.

## Stacked on #151
This branches off `feat/consolidated-readout-panel` (PR #151, intentionally still open), so this PR's diff includes #151's commits. **The new work is just these three commits** (review these):
- `bf43e26` crisp inline-SVG resource icons (currentColor)
- `eda9a25` aria-hidden + undefined-icon guard
- `2c13c44` blue header + accent bar, accented unit symbol, Resources label

## Design docs
`docs/specs/2026-06-08-readout-visual-redesign-design.md`, `docs/plans/2026-06-08-readout-visual-redesign.md`.

## Built via subagent-driven-development
Each task: implementer + spec-compliance review + code-quality review (all passed). This PR's preview channel is for the visual verification.