### PR TITLE
feat(panel): unify the Layers panel and readout into one tabbed Map panel

### DIFF
--- a/docs/handoffs/2026-06-12-right-rail-tools-restyle.md
+++ b/docs/handoffs/2026-06-12-right-rail-tools-restyle.md
@@ -1,0 +1,66 @@
+# Handoff — Right-rail tools restyle (geolMapPortal)
+
+**For a fresh session.** Read this first, then the spec/plan it references. This continues an in-flight design effort; the prior session got large, so this hands off the *next* piece.
+
+## Project basics
+- **geolMapPortal** — UGS interactive geologic map portal. **Vanilla JS** (ArcGIS Maps SDK for JavaScript 4.29 + jQuery), plain HTML/CSS. **No build step, no module system, NO test runner.**
+- **Verify:** `node --check public/mapcontrols.js`; CSS brace balance (`node -e "const s=require('fs').readFileSync('public/style.css','utf8');const o=(s.match(/{/g)||[]).length,c=(s.match(/}/g)||[]).length;console.log(o===c?'BALANCED':'MISMATCH')"`); then **manually on the PR preview channel** (the real check — there are no automated UI tests).
+- **Worktree:** `/Users/marshallrobinson/Documents/git_projects/geolMapPortal-layer-list`, branch **`feat/unified-map-panel`** (**PR #156**). Build here (or a branch off it); push → PR #156's Firebase preview redeploys; verify there.
+- **Commits:** Conventional Commits. **Never name the model / add AI attribution** anywhere (commits, PR, code) — repo rule.
+
+## The 3-PR stack (all open, await the user's preview sign-off + bottom-up merge to `dev`)
+- **#153** `feat/readout-redesign` — consolidated readout (Refined Light) + "Units" pill.
+- **#155** `feat/remove-map-downloads-mode` — removed the Map Downloads mode/swiper; footprints split.
+- **#156** `feat/unified-map-panel` — **the unified "Map" panel** (this branch). Spec/plan: `docs/specs/2026-06-11-unified-map-panel-design.md`, `docs/plans/2026-06-11-unified-map-panel.md`.
+
+## Design system to match ("Refined Light")
+- **Panels:** white. `#unitsPane` is the bottom-right panel (white, ~0.96 opacity).
+- **Cards / rows:** bg `#f5f6f8`, `1px solid #e3e3e3`, radius 5px, hover `#eceff4` (see `.map-section` and `#unitsPane #layersPanel .map-layer`).
+- **Type:** titles in `"Bebas Neue Regular"` — `#4a4a4a` (rows), `#235c87` (panel/primary). Section labels: uppercase, letter-spaced, muted `#9a9a9a`/`#9aa0a6` (`.lyr-group`, `.other-maps-label`).
+- **Accent** `#326A98` (icons, selected, accent bars). **Toggle-on** `#6396fc`.
+- **Toggle switch:** reuse `.layer-switch-slider` (30×17 pill, `#c6c6c6`→`#6396fc`, white knob) — do NOT hand-roll a look-alike.
+- **Tab bar:** `.panel-tabs` / `.panel-tab` (Bebas, accent underline when `.selected`).
+- **Range slider:** `.op-range` (native input; thin `#e3e3e3` track, accent gradient fill, `#326A98` thumb).
+
+## What #156 already is (so you don't redo it)
+`#unitsPane` is now ONE bottom-right panel with a **Layers ⇄ Identify** tab bar:
+- **Identify tab** (`#udTab`) = the readout (unchanged) + an "Extent" toggle in its head.
+- **Layers tab** = the relocated `#layersPanel` (kept its id + inputs): geology + reference layers as `.lyr-row` cards with real `.layer-switch-slider` toggles; a **Map footprints** survey toggle with the scale-filter **badges inline on its row** (`#fpScale`); a **Display** group holding the **Opacity** slider.
+- Panel `{collapsed, tab}` persists in `localStorage`.
+- **Opacity** was folded into the Display group; the standalone `#opacityPanel` flyout **and its rail icon were removed**.
+- An "auto show/hide by zoom" toggle was tried and **removed** — geology layers are **manual** (they still render within their own `min/maxScale`). Scale-dependency status **dots** (green=in-range, gray=out-of-range) sit on the Layers rows. (Known: `activateLayers` only refreshes on layer-change, not on zoom — dots can go stale; not addressed, low priority.)
+
+## YOUR TASK: restyle the rest of the right-rail tools to the design system
+The left icon column (`.leaflet-left`, `style.css` ~214-281) holds icon buttons that open **flyout panels** still in the **old dark `theme-color` (#565656)** style. Bring them to Refined Light. The user's rule: **match the design system, but NOT necessarily fold everything into the one panel.**
+
+**The tools** (icons at `index.html` ~218-281; panels nearby):
+- **Search maps** `.search` → `#searchPanel` (`#search-esri`, an Esri Search over maps; results route to the readout already). Restyle the flyout + the Esri widget.
+- **Geocoder/locate** `.geocoder` → `#geocoderPanel` (`#geocoder`, Esri Search for places). Restyle.
+- **Configuration/scale** `.configuration` → `#configPanel`. Restyle (or fold what's useful).
+- **Unit search** `.searchunits` → `#unitsrchPanel`. Restyle.
+- **Strat columns** `.strat` (toggle). Restyle.
+- **Basemap switcher** (the topo/imagery/hillshade controls near the top, `.legTopo`/`.activebase` etc.). Restyle; **the user wants reference layers (Streets & Reference, U.S. Geology — currently in the Layers tab) considered for moving INTO the basemap switcher** (they're really basemap/overlay material). This was deferred from #156.
+- **Layers** `.layers` (opens the unified panel to Layers — done). **Identify** `.identify` (click-mode icon; may be vestigial post-#155 — check before touching).
+- **Opacity** — DONE (removed).
+
+**Recommended categorization (the user approved):**
+- *Map-display* (layers, opacity, footprints, basemap) → the Map/Layers surface. Opacity folded in; basemap stays its own switcher, restyled.
+- *Find tools* (map search, geocode, unit search) → clean Refined-Light **flyouts** off the rail (or a single unified search) — NOT crammed into the panel.
+- *Utilities* (config, strat, help) → restyled popovers.
+- *The rail itself* → restyle the icon column + the buttons' open/active state (`.rightbarExpanded`).
+
+## How to work (the user's expectations — important)
+- **The user is design-sensitive and wants OPTIONS.** Use the **visual companion** (superpowers `brainstorming` skill → `scripts/start-server.sh --project-dir <worktree>`; idles after ~30 min, restart as needed; write HTML fragments to `screen_dir`; `.card`/`toggleSelect()`). Mock the rail + flyout treatments, get sign-off, THEN build. They have repeatedly (and rightly) caught blind-CSS misses.
+- **Reuse the readout's REAL components** and verify visually on the preview — don't ship CSS you've never seen rendered.
+- Mechanical wiring can go to subagents with precise specs; keep the **design/look** under your control (mock → sign-off → review on the preview).
+- Start each design topic by confirming scope with the user; build one focused piece, push, let them react on the #156 preview.
+
+## Deferred / not in scope unless asked
+- Move reference layers into the basemap switcher (the user flagged interest — confirm before doing).
+- The `activateLayers`-on-zoom dot staleness.
+- Geology layer scale-dependency thresholds (the user removed the auto-switch entirely).
+
+## Quick start for the new session
+1. `cd /Users/marshallrobinson/Documents/git_projects/geolMapPortal-layer-list` (on `feat/unified-map-panel`).
+2. Read the #156 spec/plan + skim `public/index.html` (the rail icons ~218-281, the flyout panels) and `public/style.css` (`.leaflet-left`, the `.search`/`.geocoder`/etc. icon rules, `#searchPanel`/`#geocoderPanel`/`#configPanel`/`#unitsrchPanel`, and the `#unitsPane #layersPanel` Refined-Light block to mirror).
+3. Offer the visual companion; mock the rail + flyout direction; get the user's pick; build; push; verify on the PR #156 preview.

--- a/docs/plans/2026-06-11-unified-map-panel.md
+++ b/docs/plans/2026-06-11-unified-map-panel.md
@@ -1,0 +1,320 @@
+# Unified Map Panel (Layers ⇄ Identify) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge the standalone `#layersPanel` and the click readout (`#unitsPane`) into one bottom-right panel with a **Layers ⇄ Identify** tab bar in the readout's Refined-Light language, remembering its state across visits.
+
+**Architecture:** Reuse `#unitsPane` as the container; add a tab bar; **relocate the `#layersPanel` element inside it (keeping its id + inputs)** and restyle its checkboxes as switches; switch which pane shows by tab. Split the #155 footprints control into a survey toggle (Layers) + an Extent toggle (Identify), reusing the existing footprints plumbing. Persist `{collapsed, tab}` in `localStorage`.
+
+**Tech Stack:** Vanilla JS (ArcGIS Maps SDK + jQuery), plain HTML/CSS. **No build, no test runner.** Verification per task = `node --check public/mapcontrols.js` + CSS brace-balance + `rg` + manual on the PR preview. Do NOT add tests/tooling.
+
+**Spec:** `docs/specs/2026-06-11-unified-map-panel-design.md`
+
+**Branch:** cut from `feat/remove-map-downloads-mode` (PR #155). Read cited regions before editing; match by quoted code, not line numbers.
+
+**Key existing anchors:**
+- `index.html:414-417` — `<div id="unitsPane" class="geo-units theme-color hidden"><a id="fms-close" class="close"></a><div id="udTab"></div><div id="dlTab"></div></div>`
+- `index.html:260-309` — `<div id="layersPanel" class="theme-color hidden">` … checkboxes `#500k #100k #24k`, the `.footprints-control`, `#reference #2500k`.
+- `mapcontrols.js`: `setFootprintMode` (~723), `$(document).on('click','.fp-seg-btn'…)` (~746), `highlightActiveMap` (~763), `$("#layers-button").click` (~1366), `$("#layers-close").click` (~1371), `$("#fms-close").click` (~1463), the readout primary head string (~2058).
+- `style.css`: `#unitsPane` (~1295), `.layer-switch*` switch style (~2015-2023), `#layersPanel` (~585).
+
+---
+
+## Task 1: Unified shell — tab bar, relocate `#layersPanel`, repoint open/close
+
+**Files:** `public/index.html`, `public/mapcontrols.js`, `public/style.css`
+
+- [ ] **Step 1: Move `#layersPanel` inside `#unitsPane` and add the tab bar.** In `index.html`, cut the entire `<div id="layersPanel" …>…</div>` block (260-309) from its current spot and paste it INSIDE `#unitsPane`, and add a tab bar, so `#unitsPane` becomes:
+
+```html
+        <div id="unitsPane" class="geo-units theme-color hidden">
+            <a id="fms-close" class="close" data-title="Close"></a>
+            <div id="panelTabs" class="panel-tabs" role="tablist">
+                <button type="button" class="panel-tab" data-tab="layers">Layers</button>
+                <button type="button" class="panel-tab selected" data-tab="identify">Identify</button>
+            </div>
+            <div id="layersPanel" class="theme-color">
+                <!-- existing #layersPanel inner markup, UNCHANGED for now (restyled in Task 2) -->
+            </div>
+            <div id="udTab"> </div>
+            <div id="dlTab"> </div>
+        </div>
+```
+Remove the `hidden` class from `#layersPanel` (its visibility is now driven by the tab, not that class). Leave its inner checkboxes/`.footprints-control` exactly as-is (Tasks 2 & 4 handle them).
+
+- [ ] **Step 2: Add the tab state + switcher.** In `mapcontrols.js`, near the footprints state (search `var footprintMode`), add:
+
+```js
+var panelTab = 'identify';   // which pane shows in the unified panel: 'layers' | 'identify'
+function setPanelTab(tab) {
+    panelTab = tab;
+    document.querySelectorAll('#panelTabs .panel-tab').forEach(function (b) {
+        b.classList.toggle('selected', b.dataset.tab === tab);
+    });
+    byId('layersPanel').style.display = (tab === 'layers') ? 'block' : 'none';
+    byId('udTab').style.display       = (tab === 'identify') ? 'block' : 'none';
+    byId('dlTab').style.display       = (tab === 'identify') ? '' : 'none';
+    if (typeof savePanelState === 'function') savePanelState();   // defined in Task 3
+}
+function openPanel(tab) { $("#unitsPane").removeClass("hidden"); setPanelTab(tab); }
+$(document).on('click', '#panelTabs .panel-tab', function () { setPanelTab(this.dataset.tab); });
+```
+
+- [ ] **Step 3: Repoint the Layers button to open the panel on the Layers tab.** Replace the `$("#layers-button").click` handler (1366-1369) with:
+
+```js
+$("#layers-button").click(function () {
+    if (panelTab === 'layers' && !$("#unitsPane").hasClass("hidden")) {
+        $("#unitsPane").addClass("hidden");                 // toggle closed if already showing Layers
+        if (typeof savePanelState === 'function') savePanelState();
+    } else {
+        openPanel('layers');
+    }
+    $("#layers-button").toggleClass("rightbarExpanded", !$("#unitsPane").hasClass("hidden"));
+});
+```
+Delete the `$("#layers-close").click` handler (1371-1376) — `#layers-close` is removed in Task 2.
+
+- [ ] **Step 4: Make a map click open the Identify tab.** In `fetchAttributes` (search `function fetchAttributes`), at the top after `lastUnitClick = evt;`, add `openPanel('identify');`. Then anywhere the click path currently does `$("#unitsPane").removeClass("hidden")` (the `view.on("click")` units branch and `queryUnits`), it can stay — `openPanel('identify')` is idempotent. Also in the search reroute (`search-complete`), replace its `$("#unitsPane").removeClass("hidden")` with `openPanel('identify');`.
+
+- [ ] **Step 5: Collapse on close.** The `$("#fms-close").click` handler (1463) already hides `#unitsPane` + clears the highlight; add `if (typeof savePanelState === 'function') savePanelState();` as its last line.
+
+- [ ] **Step 6: CSS — tab bar + render `#layersPanel` inline.** In `style.css`, add (near `#unitsPane`, ~1295):
+
+```css
+.panel-tabs { display: flex; flex: none; border-bottom: 1px solid #ededed; margin: -2px 0 8px; }
+.panel-tab { flex: 1; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 15px; letter-spacing: .4px; padding: 7px 0; background: #f7f9fc; color: #7a8794; border: none; cursor: pointer; position: relative; }
+.panel-tab.selected { background: #fff; color: #235c87; }
+.panel-tab.selected::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -1px; width: 44px; height: 2px; background: #326A98; border-radius: 2px; }
+/* #layersPanel now lives INSIDE #unitsPane: drop its absolute positioning so it flows as a pane */
+#unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; }
+```
+Also change the standalone `#layersPanel` rule (~585) so it no longer fixes the old position (the `#unitsPane #layersPanel` override above wins by specificity, but remove the old `position:absolute; top:182px; right:54px;` to avoid confusion — leave the rest for Task 2 to clean).
+
+- [ ] **Step 7: Verify.**
+```bash
+node --check public/mapcontrols.js
+node -e "const s=require('fs').readFileSync('public/style.css','utf8');const o=(s.match(/{/g)||[]).length,c=(s.match(/}/g)||[]).length;console.log(o===c?'BALANCED':'MISMATCH '+o+'/'+c)"
+```
+Manual (preview): click a map → panel opens on Identify (readout as before); the Layers button opens it on Layers (showing the still-old-styled checkboxes inline); tabs switch panes; close hides the whole panel.
+
+- [ ] **Step 8: Commit.**
+```bash
+git add public/index.html public/mapcontrols.js public/style.css
+git commit -m "feat(panel): unify layers + readout into one tabbed bottom-right panel"
+```
+
+---
+
+## Task 2: Restyle the Layers tab as Refined-Light switches
+
+**Files:** `public/index.html`, `public/style.css`
+
+- [ ] **Step 1: Group labels + drop old chrome.** In the relocated `#layersPanel` markup, delete `<p class="layer-panel-title …>Map Layers</p>` and `<a id="layers-close" …></a>`. Add a group label before the `#500k` row and before `#reference`:
+```html
+            <div class="lyr-group">Geology</div>
+            <!-- #500k, #100k, #24k rows -->
+            <!-- (footprints-control stays here for now; Task 4 replaces it) -->
+            <div class="lyr-group">Base &amp; reference</div>
+            <!-- #reference, #2500k rows -->
+```
+
+- [ ] **Step 2: Switch-style the checkboxes (CSS-only; inputs unchanged).** In `style.css`, add:
+```css
+.lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 12px 0 6px; }
+#unitsPane #layersPanel .map-layer { margin: 0; }
+#unitsPane #layersPanel .map-layer label { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; padding: 6px 2px; cursor: pointer; }
+#unitsPane #layersPanel .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }   /* hide native checkbox */
+#unitsPane #layersPanel .list_item + label::after { content: ""; flex: none; width: 30px; height: 17px; border-radius: 9px; background: #c6c6c6; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); transition: background .15s ease; position: relative; }
+#unitsPane #layersPanel .list_item + label::before { content: ""; position: absolute; right: 4px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.3); transform: translateX(-13px); transition: transform .15s ease; z-index: 1; }
+#unitsPane #layersPanel .list_item:checked + label::after { background: #6396fc; }
+#unitsPane #layersPanel .list_item:checked + label::before { transform: translateX(0); }
+#unitsPane #layersPanel .list_item:focus-visible + label::after { outline: 2px solid #6396fc; outline-offset: 2px; }
+```
+(The `::before` knob is positioned against the label's right edge; the `&nbsp;` in each label is harmless. If the knob alignment needs nudging, tune `right`/`translateX` against the preview.)
+
+- [ ] **Step 3: Strip the old dark panel look.** In the standalone `#layersPanel` rule (~585) remove the dark/archaic declarations (`color:#ccc`, `font-family: Bebas…`, `font-size:20px`, the paddings) — the panel now inherits the readout's white Refined-Light context. Keep nothing that fights the new styles.
+
+- [ ] **Step 4: Verify.**
+```bash
+node -e "const s=require('fs').readFileSync('public/style.css','utf8');const o=(s.match(/{/g)||[]).length,c=(s.match(/}/g)||[]).length;console.log(o===c?'BALANCED':'MISMATCH '+o+'/'+c)"
+```
+Manual: the Layers tab reads as white Refined-Light rows with toggle switches; toggling a switch still turns the geology/reference layer on/off (the underlying checkbox + `change` handler are unchanged); the readout's per-map toggle still flips the matching switch.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add public/index.html public/style.css
+git commit -m "feat(panel): restyle the Layers tab as Refined-Light switches"
+```
+
+---
+
+## Task 3: Persist panel state (first-load collapsed, then remembered)
+
+**Files:** `public/mapcontrols.js`
+
+- [ ] **Step 1: Add save/restore.** Near `setPanelTab` (Task 1), add:
+```js
+var PANEL_STATE_KEY = 'ugsMapPanel';
+function savePanelState() {
+    try {
+        localStorage.setItem(PANEL_STATE_KEY, JSON.stringify({
+            collapsed: $("#unitsPane").hasClass("hidden"),
+            tab: panelTab
+        }));
+    } catch (e) { /* storage unavailable (private mode) -- ignore */ }
+}
+function restorePanelState() {
+    var s = null;
+    try { s = JSON.parse(localStorage.getItem(PANEL_STATE_KEY)); } catch (e) { s = null; }
+    if (!s) { $("#unitsPane").addClass("hidden"); setPanelTab('identify'); return; }   // first-ever load: collapsed
+    setPanelTab(s.tab === 'layers' ? 'layers' : 'identify');
+    if (s.collapsed) $("#unitsPane").addClass("hidden"); else $("#unitsPane").removeClass("hidden");
+}
+```
+
+- [ ] **Step 2: Call restore on load.** Find where the app finishes initial setup (search for the existing `setLayerVisibility( uri.layers…` call near the bottom, ~3035, or the view `.when(...)` ready block) and add `restorePanelState();` after the UI is wired. If the Identify tab has no content yet on load, that's fine — Task 5 adds its empty state.
+
+- [ ] **Step 3: Verify.**
+```bash
+node --check public/mapcontrols.js
+```
+Manual: first load (clear `localStorage`) → panel collapsed. Open Layers, reload → restored open on Layers. Click a map (Identify), reload → restored open on Identify. Close, reload → stays collapsed.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add public/mapcontrols.js
+git commit -m "feat(panel): remember panel open/collapsed + active tab across visits"
+```
+
+---
+
+## Task 4: Footprints split — survey toggle (Layers) + Extent toggle (Identify)
+
+**Files:** `public/index.html`, `public/mapcontrols.js`, `public/style.css`
+
+- [ ] **Step 1: Replace the segmented control markup.** In the Layers tab, replace the whole `.footprints-control` block (the `.fp-seg` Off/This-map/All + `#fpScale`) with a survey switch + the scale row:
+```html
+            <div class="map-layer" id="fpSurveyRow">
+                <input type="checkbox" class="list_item fp-survey" id="fpSurvey" />
+                <label for="fpSurvey">Map footprints</label>
+            </div>
+            <div id="fpScale" class="fp-scale" hidden>
+                <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
+                <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
+                <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
+                <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
+                <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
+            </div>
+```
+(`#fpSurvey` reuses `.list_item` so it gets the switch styling from Task 2. It must NOT be wired into `setLayerVisibility`'s layer loop — see Step 4.)
+
+- [ ] **Step 2: Add the Extent toggle to the readout head.** In `buildAccordion`, change the primary head string (~2058) to include an Extent toggle after the title:
+```js
+                '<div class="readout-primary-head"><div class="readout-primary-title">' + title + '</div>' +
+                    '<label class="extent-toggle" title="Outline this map sheet on the map"><input type="checkbox" class="extent-cb"' + (footprintExtentOn ? ' checked' : '') + '><span class="extent-slider"></span><span class="extent-label">Extent</span></label>' +
+                    pill + toggle + '</div>' +
+```
+
+- [ ] **Step 3: Replace `setFootprintMode` with two booleans.** Delete `var footprintMode`, `function setFootprintMode`, and the `$(document).on('click', '.fp-seg-btn'…)` handler (723-746). Add:
+```js
+var footprintSurveyOn = false;   // Layers tab: show all footprints (+ scale filter)
+var footprintExtentOn = false;   // Identify: outline the active sheet
+
+// survey toggle (Layers tab)
+$(document).on('change', '#fpSurvey', function () {
+    footprintSurveyOn = this.checked;
+    var lyr = map.findLayerById('footprints');
+    byId('fpScale').hidden = !footprintSurveyOn;
+    if (footprintSurveyOn) { if (lyr) { lyr.visible = true; lyr.definitionExpression = footprintScaleExpr; } }
+    else {
+        if (lyr) lyr.visible = false;
+        footprintScaleExpr = "1=1";
+        document.querySelectorAll('#fpScale .scale-btn').forEach(function (b) { b.classList.remove('selected'); });
+        var allBtn = document.querySelector('#fpScale .scale-btn[data-expr="1=1"]');
+        if (allBtn) allBtn.classList.add('selected');
+    }
+});
+// extent toggle (Identify head; delegated so it survives readout rebuilds)
+$(document).on('change', '.extent-cb', function () {
+    footprintExtentOn = this.checked;
+    highlightActiveMap(currentActiveFtr());
+});
+```
+Keep the existing `$(document).on('click', '#fpScale .scale-btn'…)` handler (it sets `footprintScaleExpr` + the layer expression) as-is.
+
+- [ ] **Step 4: Point `highlightActiveMap` at the extent flag, and exclude `#fpSurvey` from the layer loop.** In `highlightActiveMap` (search `function highlightActiveMap`), change the guard `if (footprintMode !== 'thismap' || …)` to `if (!footprintExtentOn || !ftr || !ftr.geometry) return;`. Then ensure the `#fpSurvey` checkbox is not treated as a map layer: in `setLayerVisibility` and the `$("#layersPanel").change` handler, confirm they key off layer ids (`500k/100k/24k/reference/2500k`) — if they blanket-iterate `.list_item`, add `:not(.fp-survey)` to those selectors so `#fpSurvey` is skipped.
+
+- [ ] **Step 5: CSS for the Extent toggle.** In `style.css` add a compact switch mirroring `.layer-switch`:
+```css
+.extent-toggle { flex: none; display: inline-flex; align-items: center; gap: 5px; cursor: pointer; font-size: 11px; color: #326A98; user-select: none; }
+.extent-toggle input { position: absolute; opacity: 0; width: 1px; height: 1px; }
+.extent-slider { position: relative; flex: none; width: 26px; height: 15px; background: #c6c6c6; border-radius: 8px; }
+.extent-slider::after { content: ""; position: absolute; top: 2px; left: 2px; width: 11px; height: 11px; background: #fff; border-radius: 50%; box-shadow: 0 1px 2px rgba(0,0,0,.3); transition: transform .15s ease; }
+.extent-toggle input:checked + .extent-slider { background: #6396fc; }
+.extent-toggle input:checked + .extent-slider::after { transform: translateX(11px); }
+```
+
+- [ ] **Step 6: Verify.**
+```bash
+node --check public/mapcontrols.js
+node -e "const s=require('fs').readFileSync('public/style.css','utf8');const o=(s.match(/{/g)||[]).length,c=(s.match(/}/g)||[]).length;console.log(o===c?'BALANCED':'MISMATCH '+o+'/'+c)"
+rg -n "setFootprintMode|footprintMode\b|fp-seg" public/ || echo "old footprints control gone"
+```
+Manual: Layers → toggle **Map footprints** on → footprints draw + scale row appears + filters + scopes the click query; off → hidden. Identify → **Extent** on → active sheet outlines, follows sections, reverts on collapse; off → clears. Toggling tabs keeps both states.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add public/index.html public/mapcontrols.js public/style.css
+git commit -m "feat(panel): split footprints into a Layers survey toggle + an Identify extent toggle"
+```
+
+---
+
+## Task 5: Identify empty state, mobile, and final sweep
+
+**Files:** `public/mapcontrols.js`, `public/style.css`
+
+- [ ] **Step 1: Identify empty state.** When the panel opens on Identify with no readout yet (e.g., first interaction was the Layers button, or restored open-on-Identify with no click), `#udTab` is empty. In `restorePanelState` (Task 3) and `setPanelTab`, if `tab === 'identify'` and `byId('udTab').innerHTML.trim() === ''`, set it to a hint:
+```js
+    if (tab === 'identify' && !byId('udTab').innerHTML.trim()) {
+        byId('udTab').innerHTML = '<div class="readout-empty">Click the map to identify geology.</div>';
+    }
+```
+Add CSS:
+```css
+.readout-empty { padding: 22px 8px; text-align: center; color: #8a8f94; font-style: italic; font-size: 13px; }
+```
+(The next real click replaces `#udTab` via `fetchAttributes`, clearing the hint.)
+
+- [ ] **Step 2: Mobile tab bar.** Confirm the `@media (max-width: 767px)` `#unitsPane` rule (~1320) still works with the tab bar (the tabs are `flex: none` at the top; `#udTab`/`#layersPanel` scroll below). If the panel is too short for the Layers list on mobile, add under that media query:
+```css
+@media (max-width: 767px) {
+    #unitsPane #layersPanel { max-height: 50vh; }
+}
+```
+
+- [ ] **Step 3: Dead-ref + syntax sweep.**
+```bash
+node --check public/mapcontrols.js
+node -e "const s=require('fs').readFileSync('public/style.css','utf8');const o=(s.match(/{/g)||[]).length,c=(s.match(/}/g)||[]).length;console.log(o===c?'BALANCED':'MISMATCH '+o+'/'+c)"
+rg -n "setFootprintMode|footprintMode\b|fp-seg-btn|layers-close|layer-panel-title" public/ || echo "clean"
+```
+The final `rg` should print `clean` (allowing matches only inside `public/images/` archive). Fix any straggler.
+
+- [ ] **Step 4: Push + verify on preview** (manual checklist from the spec's Testing section): first-load collapsed + remembered; click→Identify; Layers button→Layers; geology/reference switches toggle layers and sync with the readout's per-map toggles; survey + Extent toggles; mobile bottom sheet; no console errors.
+
+- [ ] **Step 5: Commit any sweep fixes.**
+```bash
+git add -A && git commit -m "fix(panel): empty-state hint, mobile tabs, and cleanup sweep"
+```
+
+---
+
+## Self-review (author checklist — done)
+
+- **Spec coverage:** unified panel + tab bar → Task 1. Relocate+restyle `#layersPanel` → Tasks 1-2. Footprints split → Task 4. State persistence → Task 3. Empty state/mobile → Task 5. Identify unchanged (only the head gains the Extent toggle, Task 4 Step 2). Reference stays in Layers (Task 2). Opacity untouched.
+- **Placeholders:** none — each code step shows real code or an exact command.
+- **Identifier consistency:** `panelTab`/`setPanelTab`/`openPanel`/`savePanelState`/`restorePanelState` (Tasks 1,3); `footprintSurveyOn`/`footprintExtentOn` replace `footprintMode`/`setFootprintMode` consistently (Task 4) and `highlightActiveMap` is updated to read `footprintExtentOn`; `footprintScaleExpr` + the `#fpScale` handler are reused.
+- **Watch-items carried:** keep `#layersPanel` id + inputs (relocate, don't rebuild); re-anchor `$("#layersPanel").after(dialogNd)` if it breaks (check during Task 1); exclude `#fpSurvey` from the layer-visibility loop (Task 4 Step 4).
+- **Order safety:** structural shell first (Task 1), then restyle/persist/footprints, then sweep — the app stays usable each commit.

--- a/docs/specs/2026-06-11-unified-map-panel-design.md
+++ b/docs/specs/2026-06-11-unified-map-panel-design.md
@@ -1,0 +1,155 @@
+# Unified "Map" Panel (Layers ⇄ Identify) — Design Spec
+
+**Date:** 2026-06-11
+**Status:** Approved in brainstorm (visual companion, Direction C + detail mock); pending spec review.
+**Branch:** builds on `feat/remove-map-downloads-mode` (PR #155).
+
+## Goal
+
+Collapse the global **Layers** panel and the click-driven **readout** into ONE
+bottom-right panel with a two-tab bar — **Layers** (global, resting) and
+**Identify** (the readout) — in the readout's Refined-Light language. This fixes
+the archaic, light-gray, overlapping Layers panel by giving it the readout's home
++ style, and makes layer control available *before* a click (as the panel's
+resting state). It also reworks the #155 footprints control: the survey overlay
+becomes a Layers-tab toggle, and the "this map" extent becomes an Identify-header
+toggle.
+
+## Background — why this is low-risk
+
+- The readout (`#unitsPane`) is already the bottom-right Refined-Light panel
+  (`position:absolute; bottom; right; z-index:99; white`). We reuse it as the
+  unified container.
+- The Layers panel (`#layersPanel`) is plain checkboxes — `#500k`, `#100k`,
+  `#24k`, `#reference`, `#2500k` (class `.list_item`) — wired to
+  `setLayerVisibility` (mapcontrols.js ~63), the `$("#layersPanel").change`
+  handler (~1141), the **readout's per-map toggle** (which dispatches a `change`
+  on these checkboxes, ~2108), and URL layer-state (`$('#layersPanel').find('input')`,
+  ~3029). **We RELOCATE the `#layersPanel` element into the unified panel and
+  RESTYLE its checkboxes as switches — keeping its `id` and all its inputs — so
+  none of that wiring changes.**
+- The footprints mechanisms from #155 (the `footprints` layer, `fpHighlightLayer`
+  + `hlOutline` + `highlightActiveMap`, `footprintScaleExpr` + the scale `data-expr`
+  values, the click-query scoping) are REUSED; only the control UI is split across
+  the two tabs.
+
+## Scope
+
+- **In:** a tab bar on `#unitsPane`; relocate + restyle `#layersPanel` as the
+  Layers tab; restyle the geology/reference checkboxes as Refined-Light switches;
+  split footprints (survey toggle in Layers, Extent toggle in Identify) replacing
+  the `.footprints-control` segmented control; panel open/collapse + active-tab
+  state with first-load-collapsed then remembered (localStorage); repoint
+  `#layers-button` to open the Layers tab.
+- **Out:** any change to the Identify/readout content (unchanged); the opacity
+  flyout (stays its own control); migrating reference layers into the basemap
+  switcher (**deferred** — reference layers stay as a Layers-tab group for now);
+  the geology scale-dependency model (unchanged `min/maxScale` auto show/hide).
+  **No new libraries, no build step.**
+
+## Design
+
+### 1. The unified panel (`#unitsPane`)
+- Keep its bottom-right position + Refined-Light styling.
+- Add a **tab bar** at the very top (above `#udTab`): two tabs, **Layers** and
+  **Identify**, with the accent underline on the active one.
+- Two content panes inside: the relocated `#layersPanel` (Layers) and `#udTab`
+  (the existing readout, Identify). Show one per active tab.
+- The existing close button collapses the WHOLE panel.
+
+### 2. Layers tab — relocate + restyle `#layersPanel`
+- Move the `#layersPanel` element to be the Layers pane inside `#unitsPane`. **Keep
+  `id="layersPanel"` and every `input.list_item`** so `setLayerVisibility`, the
+  change handler, the readout sync, and URL state keep working. Drop its standalone
+  absolute positioning, the dark `.theme-color` look, the `#ccc` text, and the
+  Bebas-20 chrome.
+- **Geology group** (`#500k`, `#100k`, `#24k`): restyle the checkboxes as
+  Refined-Light toggle switches (CSS on `.list_item` + its label, mirroring the
+  readout's `.layer-switch`). Hint line: "scale-dependent — shows at the right
+  zoom." (auto show/hide unchanged.)
+- **Reference group** (`#reference`, `#2500k`): same switch styling, under a small
+  "Base & reference" label.
+- Remove the old `.layer-panel-title` text + the `#layers-close` anchor (the tab
+  bar + the panel's close button replace them).
+
+### 3. Footprints — split across the tabs (replace `.footprints-control`)
+- Remove the `.footprints-control` (Off / This map / All segmented control) and
+  `#fpScale` markup from the panel.
+- **Layers tab → a "Map footprints" survey toggle** (one switch). On → `footprints`
+  layer visible + reveal the scale filter (All / 250K / Interm / 24K / Other — the
+  existing `data-expr` values driving `footprintScaleExpr`, the layer's
+  `definitionExpression`, and the click-query scope). Off → hidden. (This is #155's
+  "All maps" behavior as a plain toggle.)
+- **Identify header → an "Extent" toggle.** On → the active readout sheet's
+  footprint outlines (`highlightActiveMap` on `fpHighlightLayer` with `hlOutline`,
+  statewide-excluded, following the open accordion section, reverting to the
+  primary on collapse). Off → cleared. (This is #155's "This map" behavior as a
+  toggle.)
+- Net: `setFootprintMode`'s three-state machine collapses into two booleans — a
+  survey flag (Layers) and an extent flag (Identify) — both reusing the same
+  underlying layer / highlight / scale plumbing.
+
+### 4. State + behavior
+- Panel state = `{ collapsed: bool, tab: 'layers' | 'identify' }`, persisted to
+  `localStorage`.
+- **First-ever load** (no stored state): collapsed.
+- **Subsequent loads:** restore the stored state (open/collapsed + tab).
+- **Click a map** → open the panel, tab = Identify (readout populates as today).
+- **`#layers-button`** → open the panel, tab = Layers.
+- **Tab clicks** switch panes; the readout DOM is preserved when on Layers, so
+  flipping back is instant.
+- **Close button** → collapse (persist).
+- **Identify before any click:** a gentle empty state ("Click the map to identify
+  geology.").
+
+## Preserved exactly
+
+The entire Identify/readout content + behavior; geology layers + scale-dependency;
+the footprints layer + highlight + scale plumbing; the opacity flyout; the basemap
+switcher; `setLayerVisibility` / the layers `change` handler / URL layer-state /
+the readout↔checkbox sync.
+
+## Migration from #155
+
+The `.footprints-control` (Off/This map/All) is removed; its two real behaviors
+move to the survey toggle (Layers) and the Extent toggle (Identify). The
+`.fp-seg*` / `#fpScale` markup and the `setFootprintMode` three-state JS are
+replaced by the two booleans; the `fpHighlightLayer` / `hlOutline` /
+`footprintScaleExpr` / scale-expr plumbing stays.
+
+## Watch-items / risks
+
+- **Relocating `#layersPanel` must keep its `id` + inputs intact** — every
+  `$("#layersPanel")…` selector and the readout's `change`-dispatch sync depend on
+  them. Restyle via CSS; do NOT rebuild the inputs.
+- **`$("#layersPanel").after(dialogNd)`** (mapcontrols.js ~3116) positions a dialog
+  after the layers panel; relocating the panel may move/break that — re-anchor it.
+- The `#layers-close` handler and the `#layers-button` / outside-click toggle logic
+  (mapcontrols.js ~500, ~1366, ~1406) must be repointed to the tab/collapse model
+  instead of the standalone `hidden`-toggle.
+- **Mobile:** `#unitsPane` is a bottom sheet on small screens; the tab bar must work
+  there too.
+- The readout's per-map toggle (`change` on a `#layersPanel` checkbox) must still
+  resolve now that the checkbox lives in the Layers tab — it will, since the
+  `id`/input is preserved.
+
+## Testing (manual — no test runner; verify on the preview)
+
+- Load → panel collapsed; open Layers, reload → restored open/Layers. Click a map →
+  Identify; toolbar Layers button → Layers; tab back and forth (readout intact).
+- Geology switches toggle the layers AND stay in sync with the readout's per-map
+  toggles; scale-dependency still auto show/hides on zoom; reference switches work.
+- Footprints **survey** toggle (Layers) draws/filters footprints + scopes the click
+  query; **Extent** toggle (Identify) outlines the active sheet, follows sections,
+  reverts on collapse, clears on off/close.
+- Mobile bottom sheet: tabs + content usable; no overlap; no console errors.
+
+## Self-review
+
+- **Placeholders:** none.
+- **Consistency:** matches the approved Direction-C detail mock (Layers ⇄ Identify,
+  Extent in the header); the Identify tab is unchanged.
+- **Scope:** unify + relocate/restyle + footprints split + persistence; readout,
+  opacity, basemap, and scale-dependency untouched; reference-→-basemap deferred.
+- **Ambiguity:** footprints become two booleans (survey / extent); `#layersPanel`
+  is relocated + restyled (not rebuilt) to preserve all wiring.

--- a/public/index.html
+++ b/public/index.html
@@ -370,7 +370,7 @@
             <div id="layersPanel" class="theme-color">
                 <div class="lyr-group">Geology</div>
                 <div class="map-layer">
-                    <input type='checkbox' class='list_item' value="0" id='500k' title='Click to Toggle Layer' /><label for='500k' title='Click to Toggle Layer' id='Lb500k'>1:500,000 Scale Maps&nbsp;</label>&nbsp;<br>
+                    <label class="lyr-row"><input type='checkbox' class='list_item' value="0" id='500k'><span class="lyr-name">1:500,000 Scale Maps</span><span class="layer-switch-slider"></span></label>
                 </div>
 
                <!-- <div class="map-layer">
@@ -378,15 +378,15 @@
                 </div>  -->
 
                 <div class="map-layer">
-                    <input type='checkbox' class='list_item' value="2" id='100k' title='Click to Toggle Layer' /><label for='100k' title='Click to Toggle Layer' id='Lb100k'>Intermediate Scale Maps&nbsp;</label><br>
+                    <label class="lyr-row"><input type='checkbox' class='list_item' value="2" id='100k'><span class="lyr-name">Intermediate Scale Maps</span><span class="layer-switch-slider"></span></label>
                 </div>
                 <div class="map-layer">
-                    <input type='checkbox' class='list_item' value="3" id='24k' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale Maps&nbsp;</label><br>
+                    <label class="lyr-row"><input type='checkbox' class='list_item' value="3" id='24k'><span class="lyr-name">1:24,000 Scale Maps</span><span class="layer-switch-slider"></span></label>
                 </div>
 
+                <div class="lyr-group">Overlays</div>
                 <div class="map-layer" id="fpSurveyRow">
-                    <input type="checkbox" class="list_item fp-survey" id="fpSurvey" />
-                    <label for="fpSurvey">Map footprints</label>
+                    <label class="lyr-row"><input type="checkbox" class="list_item fp-survey" id="fpSurvey"><span class="lyr-name">Map footprints</span><span class="layer-switch-slider"></span></label>
                 </div>
                 <div id="fpScale" class="fp-scale" hidden>
                     <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
@@ -402,10 +402,10 @@
 
                 <div class="lyr-group">Base &amp; reference</div>
                 <div class="map-layer">
-                    <input type='checkbox' class='list_item' value="5" id='reference' title='Click to Toggle Layer' onclick=' ' /><label for='reference' title='Click to Toggle Layer' id='Lbreference'>Streets & Reference&nbsp;</label><br>
+                    <label class="lyr-row"><input type='checkbox' class='list_item' value="5" id='reference' onclick=' '><span class="lyr-name">Streets &amp; Reference</span><span class="layer-switch-slider"></span></label>
                 </div>
                 <div class="map-layer">
-                    <input type='checkbox' class='list_item' value="6" id='2500k' title='Click to Toggle Layer' onclick=' ' /><label for='2500k' title='Click to Toggle Layer' id='Lb2500k'>U.S. Geology Map&nbsp;</label><br>
+                    <label class="lyr-row"><input type='checkbox' class='list_item' value="6" id='2500k' onclick=' '><span class="lyr-name">U.S. Geology Map</span><span class="layer-switch-slider"></span></label>
                 </div>
                 <!-- <div class="map-layer">
                     <input type='checkbox' class='list_item' value="7" id='ugsStratCols' title='Click to Toggle Layer' onclick=' ' /><label for='ugsStratCols' title='Click to Toggle Layer' id='LbstratCols'>Stratigraphic Columns&nbsp;</label><br>

--- a/public/index.html
+++ b/public/index.html
@@ -369,7 +369,6 @@
             </div>
             <div id="layersPanel" class="theme-color">
                 <p class="layer-panel-title tooltip mp-lyrs noselect" data-title="Turn map layers on & off">Map Layers</p>
-                <a id="layers-close" class="close" data-title="Close"></a>
 
                 <div class="map-layer">
                     <input type='checkbox' class='list_item' value="0" id='500k' title='Click to Toggle Layer' /><label for='500k' title='Click to Toggle Layer' id='Lb500k'>1:500,000 Scale Maps&nbsp;</label>&nbsp;<br>

--- a/public/index.html
+++ b/public/index.html
@@ -257,56 +257,6 @@
 
 
 
-        <div id="layersPanel" class="theme-color hidden">
-            <p class="layer-panel-title tooltip mp-lyrs noselect" data-title="Turn map layers on & off">Map Layers</p>
-            <a id="layers-close" class="close" data-title="Close"></a>
-
-            <div class="map-layer">
-                <input type='checkbox' class='list_item' value="0" id='500k' title='Click to Toggle Layer' /><label for='500k' title='Click to Toggle Layer' id='Lb500k'>1:500,000 Scale Maps&nbsp;</label>&nbsp;<br>
-            </div>
-
-           <!-- <div class="map-layer">
-                <input type='checkbox' class='list_item' value="1" id='250k' title='Click to Toggle Layer' /><label for='250k' title='Click to Toggle Layer' id='Lb250k'>1:250,000 Scale&nbsp;</label><br>
-            </div>  -->
-
-            <div class="map-layer">
-                <input type='checkbox' class='list_item' value="2" id='100k' title='Click to Toggle Layer' /><label for='100k' title='Click to Toggle Layer' id='Lb100k'>Intermediate Scale Maps&nbsp;</label><br>
-            </div>
-            <div class="map-layer">
-                <input type='checkbox' class='list_item' value="3" id='24k' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale Maps&nbsp;</label><br>
-            </div>
-
-            <div class="map-layer footprints-control">
-                <div class="fp-label">Map footprints</div>
-                <div class="fp-seg" role="group" aria-label="Map footprints">
-                    <button type="button" class="fp-seg-btn selected" data-fp="off">Off</button>
-                    <button type="button" class="fp-seg-btn" data-fp="thismap">This map</button>
-                    <button type="button" class="fp-seg-btn" data-fp="all">All maps</button>
-                </div>
-                <div id="fpScale" class="fp-scale" hidden>
-                    <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
-                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
-                    <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
-                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
-                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
-                </div>
-            </div>
-            
-            <!-- <div class="map-layer" style="display:none">
-                <input type='checkbox' class='list_item' checked='checked' value="5" id='24k-vector' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale&nbsp;</label><br>
-            </div>   -->
-           
-            <div class="map-layer">
-                <input type='checkbox' class='list_item' value="5" id='reference' title='Click to Toggle Layer' onclick=' ' /><label for='reference' title='Click to Toggle Layer' id='Lbreference'>Streets & Reference&nbsp;</label><br>
-            </div>
-            <div class="map-layer">
-                <input type='checkbox' class='list_item' value="6" id='2500k' title='Click to Toggle Layer' onclick=' ' /><label for='2500k' title='Click to Toggle Layer' id='Lb2500k'>U.S. Geology Map&nbsp;</label><br>
-            </div>
-            <!-- <div class="map-layer">
-                <input type='checkbox' class='list_item' value="7" id='ugsStratCols' title='Click to Toggle Layer' onclick=' ' /><label for='ugsStratCols' title='Click to Toggle Layer' id='LbstratCols'>Stratigraphic Columns&nbsp;</label><br>
-            </div> -->
-
-        </div>
 
 
          <!--  map config / controls  -->
@@ -413,6 +363,60 @@
         <!--  unit description flyout -->
          <div id="unitsPane" class="geo-units theme-color hidden">
             <a id="fms-close" class="close" data-title="Close"></a>
+            <div id="panelTabs" class="panel-tabs" role="tablist">
+                <button type="button" class="panel-tab" data-tab="layers">Layers</button>
+                <button type="button" class="panel-tab selected" data-tab="identify">Identify</button>
+            </div>
+            <div id="layersPanel" class="theme-color">
+                <p class="layer-panel-title tooltip mp-lyrs noselect" data-title="Turn map layers on & off">Map Layers</p>
+                <a id="layers-close" class="close" data-title="Close"></a>
+
+                <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="0" id='500k' title='Click to Toggle Layer' /><label for='500k' title='Click to Toggle Layer' id='Lb500k'>1:500,000 Scale Maps&nbsp;</label>&nbsp;<br>
+                </div>
+
+               <!-- <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="1" id='250k' title='Click to Toggle Layer' /><label for='250k' title='Click to Toggle Layer' id='Lb250k'>1:250,000 Scale&nbsp;</label><br>
+                </div>  -->
+
+                <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="2" id='100k' title='Click to Toggle Layer' /><label for='100k' title='Click to Toggle Layer' id='Lb100k'>Intermediate Scale Maps&nbsp;</label><br>
+                </div>
+                <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="3" id='24k' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale Maps&nbsp;</label><br>
+                </div>
+
+                <div class="map-layer footprints-control">
+                    <div class="fp-label">Map footprints</div>
+                    <div class="fp-seg" role="group" aria-label="Map footprints">
+                        <button type="button" class="fp-seg-btn selected" data-fp="off">Off</button>
+                        <button type="button" class="fp-seg-btn" data-fp="thismap">This map</button>
+                        <button type="button" class="fp-seg-btn" data-fp="all">All maps</button>
+                    </div>
+                    <div id="fpScale" class="fp-scale" hidden>
+                        <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
+                        <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
+                        <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
+                        <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
+                        <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
+                    </div>
+                </div>
+
+                <!-- <div class="map-layer" style="display:none">
+                    <input type='checkbox' class='list_item' checked='checked' value="5" id='24k-vector' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale&nbsp;</label><br>
+                </div>   -->
+
+                <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="5" id='reference' title='Click to Toggle Layer' onclick=' ' /><label for='reference' title='Click to Toggle Layer' id='Lbreference'>Streets & Reference&nbsp;</label><br>
+                </div>
+                <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="6" id='2500k' title='Click to Toggle Layer' onclick=' ' /><label for='2500k' title='Click to Toggle Layer' id='Lb2500k'>U.S. Geology Map&nbsp;</label><br>
+                </div>
+                <!-- <div class="map-layer">
+                    <input type='checkbox' class='list_item' value="7" id='ugsStratCols' title='Click to Toggle Layer' onclick=' ' /><label for='ugsStratCols' title='Click to Toggle Layer' id='LbstratCols'>Stratigraphic Columns&nbsp;</label><br>
+                </div> -->
+
+            </div>
             <div id="udTab"> </div>
             <div id="dlTab"> </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -386,14 +386,18 @@
 
                 <div class="lyr-group">Overlays</div>
                 <div class="map-layer" id="fpSurveyRow">
-                    <label class="lyr-row"><input type="checkbox" class="list_item fp-survey" id="fpSurvey"><span class="lyr-name">Map footprints</span><span class="layer-switch-slider"></span></label>
-                </div>
-                <div id="fpScale" class="fp-scale" hidden>
-                    <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
-                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
-                    <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
-                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
-                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
+                    <div class="lyr-row">
+                        <input type="checkbox" class="list_item fp-survey" id="fpSurvey">
+                        <label class="lyr-name" for="fpSurvey">Map footprints</label>
+                        <div id="fpScale" class="fp-scale" hidden>
+                            <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
+                            <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
+                            <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
+                            <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
+                            <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
+                        </div>
+                        <label class="fp-slider" for="fpSurvey"><span class="layer-switch-slider"></span></label>
+                    </div>
                 </div>
 
                 <!-- <div class="map-layer" style="display:none">

--- a/public/index.html
+++ b/public/index.html
@@ -368,8 +368,7 @@
                 <button type="button" class="panel-tab selected" data-tab="identify">Identify</button>
             </div>
             <div id="layersPanel" class="theme-color">
-                <p class="layer-panel-title tooltip mp-lyrs noselect" data-title="Turn map layers on & off">Map Layers</p>
-
+                <div class="lyr-group">Geology</div>
                 <div class="map-layer">
                     <input type='checkbox' class='list_item' value="0" id='500k' title='Click to Toggle Layer' /><label for='500k' title='Click to Toggle Layer' id='Lb500k'>1:500,000 Scale Maps&nbsp;</label>&nbsp;<br>
                 </div>
@@ -405,6 +404,7 @@
                     <input type='checkbox' class='list_item' checked='checked' value="5" id='24k-vector' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale&nbsp;</label><br>
                 </div>   -->
 
+                <div class="lyr-group">Base &amp; reference</div>
                 <div class="map-layer">
                     <input type='checkbox' class='list_item' value="5" id='reference' title='Click to Toggle Layer' onclick=' ' /><label for='reference' title='Click to Toggle Layer' id='Lbreference'>Streets & Reference&nbsp;</label><br>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -384,20 +384,16 @@
                     <input type='checkbox' class='list_item' value="3" id='24k' title='Click to Toggle Layer'  /><label for='24k' title='Click to Toggle Layer' id='Lb24k'>1:24,000 Scale Maps&nbsp;</label><br>
                 </div>
 
-                <div class="map-layer footprints-control">
-                    <div class="fp-label">Map footprints</div>
-                    <div class="fp-seg" role="group" aria-label="Map footprints">
-                        <button type="button" class="fp-seg-btn selected" data-fp="off">Off</button>
-                        <button type="button" class="fp-seg-btn" data-fp="thismap">This map</button>
-                        <button type="button" class="fp-seg-btn" data-fp="all">All maps</button>
-                    </div>
-                    <div id="fpScale" class="fp-scale" hidden>
-                        <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
-                        <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
-                        <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
-                        <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
-                        <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
-                    </div>
+                <div class="map-layer" id="fpSurveyRow">
+                    <input type="checkbox" class="list_item fp-survey" id="fpSurvey" />
+                    <label for="fpSurvey">Map footprints</label>
+                </div>
+                <div id="fpScale" class="fp-scale" hidden>
+                    <button type="button" class="scale-btn selected" data-expr="1=1">All</button>
+                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_1x2'">250K</button>
+                    <button type="button" class="scale-btn" data-expr="servName = '30x60_Quads'">Interm</button>
+                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_24k'">24K</button>
+                    <button type="button" class="scale-btn" data-expr="geomaps_service = 'geomaps_irreg'">Other</button>
                 </div>
 
                 <!-- <div class="map-layer" style="display:none">

--- a/public/index.html
+++ b/public/index.html
@@ -409,7 +409,7 @@
                 </div>
                 <div class="lyr-group">Display</div>
                 <div class="map-layer" id="displayGroup">
-                    <label class="disp-row"><span class="disp-name">Auto show/hide by zoom</span><input type="checkbox" class="lyr-setting" id="autoScaleToggle" checked><span class="layer-switch-slider"></span></label>
+                    <label class="disp-row"><span class="disp-name">Auto show/hide by zoom</span><input type="checkbox" class="lyr-setting" id="autoScaleToggle"><span class="layer-switch-slider"></span></label>
                     <div class="disp-div"></div>
                     <div class="disp-row"><span class="disp-name">Opacity</span><input type="range" class="lyr-setting op-range" id="opacityRange" min="0" max="1" step="0.05" value="0.8" style="background: linear-gradient(to right, #326A98 80%, #e3e3e3 80%);"><span class="disp-val" id="opacityVal">80%</span></div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -409,8 +409,6 @@
                 </div>
                 <div class="lyr-group">Display</div>
                 <div class="map-layer" id="displayGroup">
-                    <label class="disp-row"><span class="disp-name">Auto show/hide by zoom</span><input type="checkbox" class="lyr-setting" id="autoScaleToggle"><span class="layer-switch-slider"></span></label>
-                    <div class="disp-div"></div>
                     <div class="disp-row"><span class="disp-name">Opacity</span><input type="range" class="lyr-setting op-range" id="opacityRange" min="0" max="1" step="0.05" value="0.8" style="background: linear-gradient(to right, #326A98 80%, #e3e3e3 80%);"><span class="disp-val" id="opacityVal">80%</span></div>
                 </div>
                 <!-- <div class="map-layer">

--- a/public/index.html
+++ b/public/index.html
@@ -218,7 +218,6 @@
         <div id="mapcontrols" class="leaflet-bar leaflet-control leaflet-right theme-color">
             <a id="identify-button" class="identify tooltip left theme-color" href="#" data-title="Click Options"></a>
             <a id="search" class="search tooltip left theme-color" href="#" data-title="Search For Maps"></a>
-            <a id="opacity" class="opacity tooltip left theme-color" href="#" data-title="Layer Opacity"></a>
             <a id="geocoder-button" class="geocoder tooltip left theme-color" href="#" data-title="Go To a Location"></a>
             <a id="layers-button" class="layers tooltip left rightbarExpanded theme-color" href="#" data-title="Map Layer Controls"></a>
             <a id="config-button" class="configuration tooltip left theme-color" href="#" data-title="Map Config Controls"></a>
@@ -247,9 +246,6 @@
 
         <div id="searchPanel" class="theme-color hidden hide-mobile">
             <div id="search-esri"></div>
-        </div>
-        <div id="opacityPanel" class="theme-color hidden hide-mobile">
-            <div id="opSlider"></div>
         </div>
         <div id="geocoderPanel" class="theme-color hidden hide-mobile">
             <div id="geocoder"></div>
@@ -410,6 +406,12 @@
                 </div>
                 <div class="map-layer">
                     <label class="lyr-row"><input type='checkbox' class='list_item' value="6" id='2500k' onclick=' '><span class="lyr-name">U.S. Geology Map</span><span class="layer-switch-slider"></span></label>
+                </div>
+                <div class="lyr-group">Display</div>
+                <div class="map-layer" id="displayGroup">
+                    <label class="disp-row"><span class="disp-name">Auto show/hide by zoom</span><input type="checkbox" class="lyr-setting" id="autoScaleToggle" checked><span class="layer-switch-slider"></span></label>
+                    <div class="disp-div"></div>
+                    <div class="disp-row"><span class="disp-name">Opacity</span><input type="range" class="lyr-setting op-range" id="opacityRange" min="0" max="1" step="0.05" value="0.8" style="background: linear-gradient(to right, #326A98 80%, #e3e3e3 80%);"><span class="disp-val" id="opacityVal">80%</span></div>
                 </div>
                 <!-- <div class="map-layer">
                     <input type='checkbox' class='list_item' value="7" id='ugsStratCols' title='Click to Toggle Layer' onclick=' ' /><label for='ugsStratCols' title='Click to Toggle Layer' id='LbstratCols'>Stratigraphic Columns&nbsp;</label><br>

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -49,8 +49,9 @@ let map, initExtent, mapCount, unitbbox;
 // current footprint scale-filter expression (set by the "All maps" scale sub-row).
 // "1=1" = no filter. Used by the survey toggle (#fpSurvey) in the Layers tab.
 var footprintScaleExpr = "1=1";
-var autoScaleHide = true;   // global scale-dependency (auto show/hide by zoom); off = layers render at all zooms
-var savedScale = {};        // remembers each layer's original {min,max} scale so it can be restored
+var autoScale = false;      // "auto show/hide by zoom": ON = map auto-switches geology scale by zoom; OFF = manual
+var savedScale = {};        // each layer's original {min,max} scale, so it can be restored when auto is turned off
+var lastAutoScale = null;   // last geology scale auto-switch chose, to avoid redundant re-applies on every zoom tick
 // when true, the next readout sections show a "click to identify" prompt instead of querying a unit
 var readoutSearchPrompt = false;
 let lastUnitClick = null, accordionFtrs = [], accordionLoaded = {}; // current readout: click event, footprints at the point, which sections have lazy-loaded
@@ -784,21 +785,47 @@ $(document).on('input', '#opacityRange', function () {
     byId('opacityVal').innerHTML = Math.round(v * 100) + '%';
     this.style.background = 'linear-gradient(to right, #326A98 ' + (v * 100) + '%, #e3e3e3 ' + (v * 100) + '%)';
 });
-// auto show/hide by zoom: global scale-dependency toggle (off zeros each layer's scale limits so it renders everywhere)
-$(document).on('change', '#autoScaleToggle', function () {
-    autoScaleHide = this.checked;
+// most-detailed geology scale appropriate for the current zoom (thresholds are tunable)
+function bestGeologyScale() {
+    var s = view.scale;
+    if (s <= 100000) return '24k';
+    if (s <= 500000) return '100k';
+    return '500k';
+}
+// when auto is on, show only the scale that fits the current zoom; turn the other geology scales off
+function applyAutoScale() {
+    if (!autoScale) return;
+    var chosen = bestGeologyScale();
+    if (chosen === lastAutoScale) return;       // unchanged since last tick — nothing to do
+    lastAutoScale = chosen;
+    ['24k','100k','500k'].forEach(function (id) {
+        var cb = byId(id), lyr = map.findLayerById(id);
+        if (id === chosen) { if (cb) cb.checked = true; addMaps([id]); }
+        else { if (cb) cb.checked = false; if (lyr) lyr.visible = false; }
+    });
+    activateLayers();
+}
+// turn auto-switch on/off. ON: drop the layers' own scale limits so our switch fully controls rendering,
+// then apply. OFF: restore each layer's original limits and leave the layers as the user sets them.
+function setAutoScale(on) {
+    autoScale = on;
+    var t = byId('autoScaleToggle'); if (t) t.checked = on;
     $.each($('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)'), function (i, item) {
         var lyr = map.findLayerById(item.id);
         if (!lyr) return;
-        if (!autoScaleHide) {
+        if (on) {
             if (!(item.id in savedScale)) savedScale[item.id] = { min: lyr.minScale, max: lyr.maxScale };
             lyr.minScale = 0; lyr.maxScale = 0;
         } else if (item.id in savedScale) {
             lyr.minScale = savedScale[item.id].min; lyr.maxScale = savedScale[item.id].max;
         }
     });
-    activateLayers();
-});
+    lastAutoScale = null;
+    if (on) applyAutoScale(); else activateLayers();
+}
+$(document).on('change', '#autoScaleToggle', function () { setAutoScale(this.checked); });
+// re-evaluate the auto scale whenever the zoom changes
+reactiveUtils.watch( function () { return view.scale; }, function () { if (autoScale) applyAutoScale(); });
 // extent toggle (Identify head; delegated so it survives readout rebuilds)
 $(document).on('change', '.extent-cb', function () {
     footprintExtentOn = this.checked;
@@ -1258,7 +1285,7 @@ function activateLayers(){
         //console.log(item.id);
         var lyr = map.findLayerById(item.id);
         // if layer doesn't have min or maxScale set, this will not work
-        if ( lyr && byId(lyr.id).checked && (!autoScaleHide || (lyr.minScale > view.scale && lyr.maxScale < view.scale))){
+        if ( lyr && byId(lyr.id).checked && (autoScale || (lyr.minScale > view.scale && lyr.maxScale < view.scale))){
             byId(item.id).parentNode.style.opacity = 1.0;
             byId(item.id).parentNode.classList.remove( "greyedout" );
             byId(item.id).parentNode.classList.add( "setactive" );

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -720,6 +720,20 @@ function addFootprints(){
 addFootprints();
 
 // "Map footprints" panel control: off (hidden) / thismap (active-map outline, Task 3) / all (show layer + scale filter)
+var panelTab = 'identify';   // which pane shows in the unified panel: 'layers' | 'identify'
+function setPanelTab(tab) {
+    panelTab = tab;
+    document.querySelectorAll('#panelTabs .panel-tab').forEach(function (b) {
+        b.classList.toggle('selected', b.dataset.tab === tab);
+    });
+    byId('layersPanel').style.display = (tab === 'layers') ? 'block' : 'none';
+    byId('udTab').style.display       = (tab === 'identify') ? 'block' : 'none';
+    byId('dlTab').style.display       = (tab === 'identify') ? '' : 'none';
+    if (typeof savePanelState === 'function') savePanelState();   // defined in Task 3
+}
+function openPanel(tab) { $("#unitsPane").removeClass("hidden"); setPanelTab(tab); }
+$(document).on('click', '#panelTabs .panel-tab', function () { setPanelTab(this.dataset.tab); });
+
 var footprintMode = 'off';
 function setFootprintMode(mode) {
     footprintMode = mode;
@@ -1364,15 +1378,13 @@ $(".left-arrow").click(function () {
 // add click handlers to toggle control panels
 // also toggle the tooltip class to hide when panel is open
 $("#layers-button").click(function () {
-    $("#layersPanel").toggleClass("hidden");
-    $("#layers-button").toggleClass("rightbarExpanded");
-});
-
-$("#layers-close").click(function () {
-    //$("#layersPanel").toggle("slide", {direction:'left'} );
-    $("#layersPanel").toggleClass("hidden");
-    $("#layers-button").toggleClass("rightbarExpanded");
-    //$("#layersPanel").animate({left: "-150px"}, 450);
+    if (panelTab === 'layers' && !$("#unitsPane").hasClass("hidden")) {
+        $("#unitsPane").addClass("hidden");                 // toggle closed if already showing Layers
+        if (typeof savePanelState === 'function') savePanelState();
+    } else {
+        openPanel('layers');
+    }
+    $("#layers-button").toggleClass("rightbarExpanded", !$("#unitsPane").hasClass("hidden"));
 });
 
 $(".configuration").click(function () {
@@ -1465,6 +1477,7 @@ $("#fms-close").click(function () {
     $("#unitsPane").addClass("hidden");
     fpHighlightLayer.removeAll();
     view.graphics.removeAll();
+    if (typeof savePanelState === 'function') savePanelState();
 });
 
 // open the search input
@@ -2112,6 +2125,7 @@ function toggleLayerFromSection(scaleId, checked) {
 // figure out which footprints cover the click point and render them as an accordion
 function fetchAttributes(ftrset, evt) {
     lastUnitClick = evt;
+    openPanel('identify');
     // every footprint at the point becomes a section, most-detailed (smallest scale) first
     accordionFtrs = ftrset.slice().sort(function (a, b) {
         var ds = parseInt(a.attributes.scale) - parseInt(b.attributes.scale);   // most-detailed scale first
@@ -2481,7 +2495,7 @@ searchMaps.on("search-complete", function (e) {
     view.goTo(ext.expand ? ext.expand(1.3) : ext);
     var syntheticEvt = { mapPoint: ext.center };     // no clicked point; use the map's center
     readoutSearchPrompt = true;
-    $("#unitsPane").removeClass("hidden");
+    openPanel('identify');
     byId('udTab').innerHTML = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;loading map…</div>';
     fetchAttributes(ftrset, syntheticEvt);
     searchMaps.blur();
@@ -3113,7 +3127,9 @@ function addSliderControl(layer, inpt) {
     });
     var label = "Lb" + inpt;
     $("#" + label).append(button);
-    $("#layersPanel").after(dialogNd); // needs to be AFTER the layers panel or messes up positioning
+    // #layersPanel now lives inside #unitsPane (overflow:hidden); anchor the dialog after #unitsPane
+    // so it isn't clipped and retains its absolute positioning relative to the page stacking context
+    $("#unitsPane").after(dialogNd);
     //byId("layersPanel").append(dialogNd);
 
     //$('<div id="scaleslider' + inpt + '"></div>').appendTo(sliderNd)

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -732,6 +732,23 @@ function setPanelTab(tab) {
 function openPanel(tab) { $("#unitsPane").removeClass("hidden"); setPanelTab(tab); }
 $(document).on('click', '#panelTabs .panel-tab', function () { setPanelTab(this.dataset.tab); });
 
+var PANEL_STATE_KEY = 'ugsMapPanel';
+function savePanelState() {
+    try {
+        localStorage.setItem(PANEL_STATE_KEY, JSON.stringify({
+            collapsed: $("#unitsPane").hasClass("hidden"),
+            tab: panelTab
+        }));
+    } catch (e) { /* storage unavailable (private mode) -- ignore */ }
+}
+function restorePanelState() {
+    var s = null;
+    try { s = JSON.parse(localStorage.getItem(PANEL_STATE_KEY)); } catch (e) { s = null; }
+    if (!s) { $("#unitsPane").addClass("hidden"); setPanelTab('identify'); return; }   // first-ever load: collapsed
+    setPanelTab(s.tab === 'layers' ? 'layers' : 'identify');
+    if (s.collapsed) $("#unitsPane").addClass("hidden"); else $("#unitsPane").removeClass("hidden");
+}
+
 var footprintMode = 'off';
 function setFootprintMode(mode) {
     footprintMode = mode;
@@ -3045,6 +3062,7 @@ function getLayerVisibility() {
 
 
 setLayerVisibility( uri.layers.replace(/[\(\)]/g, '').split(',') );
+restorePanelState();
 
 // listen for keypress to turn off layers so user can see where they are on map more easily
 $(document).keypress(function(e) {

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -49,9 +49,7 @@ let map, initExtent, mapCount, unitbbox;
 // current footprint scale-filter expression (set by the "All maps" scale sub-row).
 // "1=1" = no filter. Used by the survey toggle (#fpSurvey) in the Layers tab.
 var footprintScaleExpr = "1=1";
-var autoScale = false;      // "auto show/hide by zoom": ON = map auto-switches geology scale by zoom; OFF = manual
-var savedScale = {};        // each layer's original {min,max} scale, so it can be restored when auto is turned off
-var lastAutoScale = null;   // last geology scale auto-switch chose, to avoid redundant re-applies on every zoom tick
+// (auto show/hide by zoom removed — geology layers are manual; opacity lives in the Display group)
 // when true, the next readout sections show a "click to identify" prompt instead of querying a unit
 var readoutSearchPrompt = false;
 let lastUnitClick = null, accordionFtrs = [], accordionLoaded = {}; // current readout: click event, footprints at the point, which sections have lazy-loaded
@@ -785,47 +783,7 @@ $(document).on('input', '#opacityRange', function () {
     byId('opacityVal').innerHTML = Math.round(v * 100) + '%';
     this.style.background = 'linear-gradient(to right, #326A98 ' + (v * 100) + '%, #e3e3e3 ' + (v * 100) + '%)';
 });
-// most-detailed geology scale appropriate for the current zoom (thresholds are tunable)
-function bestGeologyScale() {
-    var s = view.scale;
-    if (s <= 100000) return '24k';
-    if (s <= 500000) return '100k';
-    return '500k';
-}
-// when auto is on, show only the scale that fits the current zoom; turn the other geology scales off
-function applyAutoScale() {
-    if (!autoScale) return;
-    var chosen = bestGeologyScale();
-    if (chosen === lastAutoScale) return;       // unchanged since last tick — nothing to do
-    lastAutoScale = chosen;
-    ['24k','100k','500k'].forEach(function (id) {
-        var cb = byId(id), lyr = map.findLayerById(id);
-        if (id === chosen) { if (cb) cb.checked = true; addMaps([id]); }
-        else { if (cb) cb.checked = false; if (lyr) lyr.visible = false; }
-    });
-    activateLayers();
-}
-// turn auto-switch on/off. ON: drop the layers' own scale limits so our switch fully controls rendering,
-// then apply. OFF: restore each layer's original limits and leave the layers as the user sets them.
-function setAutoScale(on) {
-    autoScale = on;
-    var t = byId('autoScaleToggle'); if (t) t.checked = on;
-    $.each($('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)'), function (i, item) {
-        var lyr = map.findLayerById(item.id);
-        if (!lyr) return;
-        if (on) {
-            if (!(item.id in savedScale)) savedScale[item.id] = { min: lyr.minScale, max: lyr.maxScale };
-            lyr.minScale = 0; lyr.maxScale = 0;
-        } else if (item.id in savedScale) {
-            lyr.minScale = savedScale[item.id].min; lyr.maxScale = savedScale[item.id].max;
-        }
-    });
-    lastAutoScale = null;
-    if (on) applyAutoScale(); else activateLayers();
-}
-$(document).on('change', '#autoScaleToggle', function () { setAutoScale(this.checked); });
-// re-evaluate the auto scale whenever the zoom changes
-reactiveUtils.watch( function () { return view.scale; }, function () { if (autoScale) applyAutoScale(); });
+// (auto show/hide by zoom feature removed per design — geology layers are toggled manually)
 // extent toggle (Identify head; delegated so it survives readout rebuilds)
 $(document).on('change', '.extent-cb', function () {
     footprintExtentOn = this.checked;
@@ -1285,7 +1243,7 @@ function activateLayers(){
         //console.log(item.id);
         var lyr = map.findLayerById(item.id);
         // if layer doesn't have min or maxScale set, this will not work
-        if ( lyr && byId(lyr.id).checked && (autoScale || (lyr.minScale > view.scale && lyr.maxScale < view.scale))){
+        if ( lyr && byId(lyr.id).checked && lyr.minScale > view.scale && lyr.maxScale < view.scale){
             byId(item.id).parentNode.style.opacity = 1.0;
             byId(item.id).parentNode.classList.remove( "greyedout" );
             byId(item.id).parentNode.classList.add( "setactive" );

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -49,6 +49,8 @@ let map, initExtent, mapCount, unitbbox;
 // current footprint scale-filter expression (set by the "All maps" scale sub-row).
 // "1=1" = no filter. Used by the survey toggle (#fpSurvey) in the Layers tab.
 var footprintScaleExpr = "1=1";
+var autoScaleHide = true;   // global scale-dependency (auto show/hide by zoom); off = layers render at all zooms
+var savedScale = {};        // remembers each layer's original {min,max} scale so it can be restored
 // when true, the next readout sections show a "click to identify" prompt instead of querying a unit
 var readoutSearchPrompt = false;
 let lastUnitClick = null, accordionFtrs = [], accordionLoaded = {}; // current readout: click event, footprints at the point, which sections have lazy-loaded
@@ -63,7 +65,7 @@ const byId = function(id) {
 function setLayerVisibility(array) {
     //console.log(array);
     // if the input.id is found in the array, then set input checked property to true.
-    $('#layersPanel').find('input:not(.fp-survey)').each(function(index, input){
+    $('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)').each(function(index, input){
         (array.indexOf(input.id) !== -1) ? $(input)[0].checked = true: $(input)[0].checked = false;
     });
     addMaps(array);
@@ -775,6 +777,28 @@ $(document).on('change', '#fpSurvey', function () {
         if (allBtn) allBtn.classList.add('selected');
     }
 });
+// opacity range (Display group): drive changeOpacity + the % readout + the slider fill
+$(document).on('input', '#opacityRange', function () {
+    var v = parseFloat(this.value);
+    changeOpacity(v);
+    byId('opacityVal').innerHTML = Math.round(v * 100) + '%';
+    this.style.background = 'linear-gradient(to right, #326A98 ' + (v * 100) + '%, #e3e3e3 ' + (v * 100) + '%)';
+});
+// auto show/hide by zoom: global scale-dependency toggle (off zeros each layer's scale limits so it renders everywhere)
+$(document).on('change', '#autoScaleToggle', function () {
+    autoScaleHide = this.checked;
+    $.each($('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)'), function (i, item) {
+        var lyr = map.findLayerById(item.id);
+        if (!lyr) return;
+        if (!autoScaleHide) {
+            if (!(item.id in savedScale)) savedScale[item.id] = { min: lyr.minScale, max: lyr.maxScale };
+            lyr.minScale = 0; lyr.maxScale = 0;
+        } else if (item.id in savedScale) {
+            lyr.minScale = savedScale[item.id].min; lyr.maxScale = savedScale[item.id].max;
+        }
+    });
+    activateLayers();
+});
 // extent toggle (Identify head; delegated so it survives readout rebuilds)
 $(document).on('change', '.extent-cb', function () {
     footprintExtentOn = this.checked;
@@ -1178,7 +1202,7 @@ reactiveUtils.watch( () => view.zoom,
 //$('.map-layer input:checkbox').on('change', function() {
 $("#layersPanel").change(function (e) {
     // #fpSurvey reuses .list_item for switch styling but is not a map layer — skip it here
-    if (e.target.classList.contains('fp-survey')) return;
+    if (e.target.classList.contains('fp-survey') || e.target.classList.contains('lyr-setting')) return;
 
     var input = e.target.id;     //get the id of the checkbox
     console.log(e.target.id);
@@ -1230,11 +1254,11 @@ $("#unitsPane").on("keydown", ".map-section-header", function (e) {
 // grey out non-active layers, make active layers show in layers panel
 function activateLayers(){
     //map.layers.forEach(function (lyr, i) {
-    $.each($('#layersPanel').find('input:not(.fp-survey)'), function(index, item){
+    $.each($('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)'), function(index, item){
         //console.log(item.id);
         var lyr = map.findLayerById(item.id);
         // if layer doesn't have min or maxScale set, this will not work
-        if ( lyr && lyr.minScale > view.scale && lyr.maxScale < view.scale && byId(lyr.id).checked){
+        if ( lyr && byId(lyr.id).checked && (!autoScaleHide || (lyr.minScale > view.scale && lyr.maxScale < view.scale))){
             byId(item.id).parentNode.style.opacity = 1.0;
             byId(item.id).parentNode.classList.remove( "greyedout" );
             byId(item.id).parentNode.classList.add( "setactive" );
@@ -1249,7 +1273,7 @@ function activateLayers(){
 // green or grey out non-active layers, make active layers show in layers panel
 // is this repeating code from activeLayers() function? (only fires when search units is used)
 function selectIntermediate(){
-    $.each($('#layersPanel').find('input:not(.fp-survey)'), function(index, item){
+    $.each($('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)'), function(index, item){
         //var lyr = map.findLayerById(item.id);
         //console.log(item.id);
         if ( item.id === '100k'){
@@ -1476,13 +1500,6 @@ $("#help-close").click(function () {
     //$("#mapHelp").toggle("slide", {direction:'left'} );
     $("#mapHelp").toggleClass("hidden");
     //$("#mapHelp").animate({left: "-150px"}, 450);
-});
-
-$(".opacity").click(function () {
-    $("#opacityPanel").toggle("slide", {
-        direction: 'right'
-    });
-    $(".opacity").toggleClass("rightbarExpanded");
 });
 
 $(".geocoder").click(function () {
@@ -2990,23 +3007,6 @@ view.when(function() {
    //view.whenLayerView(layers[0]).then(function(layerView) {
 
 
-const opslider = new Slider({
-    container: "opSlider",
-    min: 0,
-    max: 1,
-    values: [ 0.8 ],
-    snapOnClickEnabled: false,
-    steps: 0.1,
-    visibleElements: {
-        labels: true,
-        rangeLabels: false
-    }
-});
-opslider.on("thumb-drag", function (e) {
-    changeOpacity(e.value);
-});
-
-
 $("#home-div").click(function (e) {
     //var pt = new Point({x: -12389859.3, y: 4779131.18, z: 9.313, spatialReference: 102100});
     view.zoom = 7;
@@ -3069,7 +3069,7 @@ function updateURL(){
 }
 
 function getLayerVisibility() {
-    return $.map($('#layersPanel').find('input:not(.fp-survey)'), function(input,index){
+    return $.map($('#layersPanel').find('input:not(.fp-survey):not(.lyr-setting)'), function(input,index){
         if ($(input)[0].checked == true) return input.id;
     }).join(',');
 }

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -63,7 +63,7 @@ const byId = function(id) {
 function setLayerVisibility(array) {
     //console.log(array);
     // if the input.id is found in the array, then set input checked property to true.
-    $('#layersPanel').find('input').each(function(index, input){
+    $('#layersPanel').find('input:not(.fp-survey)').each(function(index, input){
         (array.indexOf(input.id) !== -1) ? $(input)[0].checked = true: $(input)[0].checked = false;
     });
     addMaps(array);
@@ -717,7 +717,6 @@ function addFootprints(){
 }
 addFootprints();
 
-// "Map footprints" panel control: off (hidden) / thismap (active-map outline, Task 3) / all (show layer + scale filter)
 var panelTab = 'identify';   // which pane shows in the unified panel: 'layers' | 'identify'
 function setPanelTab(tab) {
     panelTab = tab;
@@ -1221,7 +1220,7 @@ $("#unitsPane").on("keydown", ".map-section-header", function (e) {
 // grey out non-active layers, make active layers show in layers panel
 function activateLayers(){
     //map.layers.forEach(function (lyr, i) {
-    $.each($('#layersPanel').find('input'), function(index, item){
+    $.each($('#layersPanel').find('input:not(.fp-survey)'), function(index, item){
         //console.log(item.id);
         var lyr = map.findLayerById(item.id);
         // if layer doesn't have min or maxScale set, this will not work
@@ -1240,7 +1239,7 @@ function activateLayers(){
 // green or grey out non-active layers, make active layers show in layers panel
 // is this repeating code from activeLayers() function? (only fires when search units is used)
 function selectIntermediate(){
-    $.each($('#layersPanel').find('input'), function(index, item){
+    $.each($('#layersPanel').find('input:not(.fp-survey)'), function(index, item){
         //var lyr = map.findLayerById(item.id);
         //console.log(item.id);
         if ( item.id === '100k'){
@@ -3060,7 +3059,7 @@ function updateURL(){
 }
 
 function getLayerVisibility() {
-    return $.map($('#layersPanel').find('input'), function(input,index){
+    return $.map($('#layersPanel').find('input:not(.fp-survey)'), function(input,index){
         if ($(input)[0].checked == true) return input.id;
     }).join(',');
 }

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -47,7 +47,7 @@ require([
 
 let map, initExtent, mapCount, unitbbox;
 // current footprint scale-filter expression (set by the "All maps" scale sub-row).
-// "1=1" = no filter. Owned by setFootprintMode() in the Layers panel control.
+// "1=1" = no filter. Used by the survey toggle (#fpSurvey) in the Layers tab.
 var footprintScaleExpr = "1=1";
 // when true, the next readout sections show a "click to identify" prompt instead of querying a unit
 var readoutSearchPrompt = false;
@@ -749,30 +749,30 @@ function restorePanelState() {
     if (s.collapsed) $("#unitsPane").addClass("hidden"); else $("#unitsPane").removeClass("hidden");
 }
 
-var footprintMode = 'off';
-function setFootprintMode(mode) {
-    footprintMode = mode;
-    document.querySelectorAll('.fp-seg-btn').forEach(function (b) {
-        b.classList.toggle('selected', b.dataset.fp === mode);
-    });
+var footprintSurveyOn = false;   // Layers tab: show all footprints (+ scale filter)
+var footprintExtentOn = false;   // Identify: outline the active sheet
+
+// survey toggle (Layers tab)
+$(document).on('change', '#fpSurvey', function () {
+    footprintSurveyOn = this.checked;
     var lyr = map.findLayerById('footprints');
-    byId('fpScale').hidden = (mode !== 'all');
-    if (mode === 'all') {
-        if (lyr) { lyr.visible = true; lyr.definitionExpression = footprintScaleExpr; }
-    } else {
+    byId('fpScale').hidden = !footprintSurveyOn;
+    if (footprintSurveyOn) { if (lyr) { lyr.visible = true; lyr.definitionExpression = footprintScaleExpr; } }
+    else {
         if (lyr) lyr.visible = false;
-        footprintScaleExpr = "1=1";                 // click query unscoped unless surveying
-        // keep the scale row's highlight in sync with the reset filter (no stale "250K" selection)
+        footprintScaleExpr = "1=1";
         document.querySelectorAll('#fpScale .scale-btn').forEach(function (b) { b.classList.remove('selected'); });
         var allBtn = document.querySelector('#fpScale .scale-btn[data-expr="1=1"]');
         if (allBtn) allBtn.classList.add('selected');
-        highlightActiveMap(null);                   // defined in Task 3; clears any outline
     }
-    if (mode === 'thismap') highlightActiveMap(currentActiveFtr());   // defined in Task 3
-}
+});
+// extent toggle (Identify head; delegated so it survives readout rebuilds)
+$(document).on('change', '.extent-cb', function () {
+    footprintExtentOn = this.checked;
+    highlightActiveMap(currentActiveFtr());
+});
 
-// segmented control + scale sub-row wiring
-$(document).on('click', '.fp-seg-btn', function () { setFootprintMode(this.dataset.fp); });
+// scale sub-row wiring
 $(document).on('click', '#fpScale .scale-btn', function () {
     document.querySelectorAll('#fpScale .scale-btn').forEach(function (b) { b.classList.remove('selected'); });
     this.classList.add('selected');
@@ -793,7 +793,7 @@ function currentActiveFtr() {
 }
 function highlightActiveMap(ftr) {
     fpHighlightLayer.removeAll();
-    if (footprintMode !== 'thismap' || !ftr || !ftr.geometry) return;
+    if (!footprintExtentOn || !ftr || !ftr.geometry) return;
     if (parseInt(ftr.attributes.scale) >= 500) return;   // skip statewide (1:500,000) and coarser
     fpHighlightLayer.add(new Graphic({ geometry: ftr.geometry, symbol: hlOutline }));
 }
@@ -1168,6 +1168,9 @@ reactiveUtils.watch( () => view.zoom,
 //Register events on the checkbox & change layer visibility
 //$('.map-layer input:checkbox').on('change', function() {
 $("#layersPanel").change(function (e) {
+    // #fpSurvey reuses .list_item for switch styling but is not a map layer — skip it here
+    if (e.target.classList.contains('fp-survey')) return;
+
     var input = e.target.id;     //get the id of the checkbox
     console.log(e.target.id);
 
@@ -2083,7 +2086,9 @@ function buildAccordion(ftrs, openIdx) {
         var readout = '<div class="map-section-readout" data-idx="' + idx + '"></div>';
         if (k === 0) {
             primaryHtml = '<div class="readout-primary' + offCls + '" data-idx="' + idx + '">' +
-                '<div class="readout-primary-head"><div class="readout-primary-title">' + title + '</div>' + pill + toggle + '</div>' +
+                '<div class="readout-primary-head"><div class="readout-primary-title">' + title + '</div>' +
+                    '<label class="extent-toggle" title="Outline this map sheet on the map"><input type="checkbox" class="extent-cb"' + (footprintExtentOn ? ' checked' : '') + '><span class="extent-slider"></span><span class="extent-label">Extent</span></label>' +
+                    pill + toggle + '</div>' +
                 readout + '</div>';
         } else {
             cardsHtml += '<div class="map-section' + offCls + '" data-idx="' + idx + '">' +

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -726,6 +726,9 @@ function setPanelTab(tab) {
     byId('layersPanel').style.display = (tab === 'layers') ? 'block' : 'none';
     byId('udTab').style.display       = (tab === 'identify') ? 'block' : 'none';
     byId('dlTab').style.display       = (tab === 'identify') ? '' : 'none';
+    if (tab === 'identify' && !byId('udTab').innerHTML.trim()) {
+        byId('udTab').innerHTML = '<div class="readout-empty">Click the map to identify geology.</div>';
+    }
     if (typeof savePanelState === 'function') savePanelState();   // defined in Task 3
 }
 function openPanel(tab) { $("#unitsPane").removeClass("hidden"); setPanelTab(tab); }
@@ -745,7 +748,14 @@ function restorePanelState() {
     try { s = JSON.parse(localStorage.getItem(PANEL_STATE_KEY)); } catch (e) { s = null; }
     if (!s) { $("#unitsPane").addClass("hidden"); setPanelTab('identify'); return; }   // first-ever load: collapsed
     setPanelTab(s.tab === 'layers' ? 'layers' : 'identify');
-    if (s.collapsed) $("#unitsPane").addClass("hidden"); else $("#unitsPane").removeClass("hidden");
+    if (s.collapsed) {
+        $("#unitsPane").addClass("hidden");
+    } else {
+        $("#unitsPane").removeClass("hidden");
+        if (s.tab !== 'layers' && !byId('udTab').innerHTML.trim()) {
+            byId('udTab').innerHTML = '<div class="readout-empty">Click the map to identify geology.</div>';
+        }
+    }
 }
 
 var footprintSurveyOn = false;   // Layers tab: show all footprints (+ scale filter)

--- a/public/mapcontrols.js
+++ b/public/mapcontrols.js
@@ -495,11 +495,9 @@ if (/iPhone|iPad|iPod|Android|webOS|BlackBerry|IEMobile|Opera Mini/i.test(naviga
 {
     //map.scale = 3000000;
     // hide sceneview controls
-} else 
-{     // if desktop, layer list open by default
-    $("#layersPanel").toggleClass("hidden");
-    //document.getElementById("myDIV").classList.toggle("hidden")
-}  
+} else
+{     // desktop: the unified panel defaults collapsed (see restorePanelState); no auto-open
+}
 
 
 var locateBtn = new Locate({
@@ -1420,12 +1418,12 @@ $("#mapcontrols").click(function (event) {
         $("#unitsrchPanel").addClass("hidden");
     };
     if ( event.target.id == "config-button") {
-        $("#layersPanel").addClass("hidden");
+        $("#unitsPane").addClass("hidden");
         $("#unitsrchPanel").addClass("hidden");
     };
     if ( event.target.id == "srchunits-button") {
         $("#configPanel").addClass("hidden");
-        $("#layersPanel").addClass("hidden");
+        $("#unitsPane").addClass("hidden");
     }; 
 });
 
@@ -1832,7 +1830,7 @@ view.on("click", function (evt) {
                     return a.attributes.scale - b.attributes.scale;
                 });
                 // every click opens the readout, regardless of what footprints are showing
-                $("#unitsPane").removeClass("hidden");
+                openPanel('identify');
                 byId('udTab').innerHTML = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;fetching unit description...</div>';
                 fetchAttributes(ftrset, evt);
                 
@@ -1867,7 +1865,7 @@ function queryUnits(evt){
 
         html = '<div><img height="14" src="images/loading.gif" alt="loader">&nbsp;fetching unit description...</div>';
         byId('udTab').innerHTML = html;
-        $("#unitsPane").removeClass("hidden");
+        openPanel('identify');
         fetchAttributes(ftrset, evt);
     })
     .catch(function (error) {
@@ -1901,7 +1899,7 @@ function printMSFms(sdata)
 {
     // redo this .append the right way.
 	$.each(sdata.mapData, function(i, sdx) {
-       $("#unitsPane").removeClass("hidden");
+       openPanel('identify');
 
        var unidesc = '<div>' + '<div class="unit-desc-title">' + sdx.name + '</div><div class="unit-age">(' + sdx.age + ')</div>' + '<hr>' + 
             '<div class="unit-desc-text">' + sdx.descrip + '</div>' + 

--- a/public/style.css
+++ b/public/style.css
@@ -782,16 +782,10 @@ overflow-y: hidden;
     margin: 4px 0;
     background: #808080;
 }
-.greyedout::before {
-    content: "|";
-    /* background: rgb(146, 235, 173);
-     outline: 1px solid red; */
-     color: #ef8067;
-}
-.setactive::before {
-    content: "|";
-    color: #82a982;
-}
+/* scale-dependency status dot before the layer name: green = visible at this zoom, gray = zoom in to view */
+.lyr-row.setactive .lyr-name::before, .lyr-row.greyedout .lyr-name::before { content: ""; display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 7px; vertical-align: middle; }
+.lyr-row.setactive .lyr-name::before { background: #58a55c; }
+.lyr-row.greyedout .lyr-name::before { background: #c4ccd2; }
 .map-layer:hover {
     background: #8b8b8b;
     filter: drop-shadow(0 0 4px #3a3939);
@@ -1306,12 +1300,12 @@ p:last-child {
 #unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; flex: 1 1 auto; min-height: 0; background: transparent; }
 
 /* Layers tab rows: reuse the readout's real .layer-switch-slider so they match the Identify side */
-.lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 13px 0 5px; }
-#unitsPane #layersPanel .map-layer { margin: 0; background: transparent; border-radius: 0; }
-#unitsPane #layersPanel .map-layer:hover { background: #f4f7fb; filter: none; border-radius: 6px; }
-#unitsPane #layersPanel .lyr-row { display: flex; align-items: center; gap: 10px; padding: 7px 2px; cursor: pointer; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; }
+.lyr-group { font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 12px; letter-spacing: .6px; text-transform: uppercase; color: #9a9a9a; margin: 14px 0 5px; }
+#unitsPane #layersPanel .map-layer { margin: 0 0 6px; background: #f5f6f8; border: 1px solid #e3e3e3; border-radius: 5px; transition: background .15s ease, border-color .15s ease; }
+#unitsPane #layersPanel .map-layer:hover { background: #eceff4; filter: none; }
+#unitsPane #layersPanel .lyr-row { display: flex; align-items: center; gap: 8px; padding: 8px 10px; cursor: pointer; }
 #unitsPane #layersPanel .lyr-row .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }
-#unitsPane #layersPanel .lyr-name { flex: 1; min-width: 0; }
+#unitsPane #layersPanel .lyr-name { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 14px; letter-spacing: .3px; line-height: 1.15; color: #4a4a4a; }
 #unitsPane #layersPanel .lyr-row .list_item:checked ~ .layer-switch-slider { background: #6396fc; }
 #unitsPane #layersPanel .lyr-row .list_item:checked ~ .layer-switch-slider::after { transform: translateX(13px); }
 #unitsPane #layersPanel .lyr-row .list_item:focus-visible ~ .layer-switch-slider { outline: 2px solid #6396fc; outline-offset: 2px; }
@@ -2029,10 +2023,7 @@ p:last-child {
 .units-pill { flex: none; font-family: 'Open Sans', sans-serif; font-size: 9px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; color: #fff; background: #326A98; border-radius: 4px; padding: 2px 6px; line-height: 1; -webkit-font-smoothing: antialiased; }
 
 /* gray a map's title when its layer is off (mirrors the layer list) */
-.readout-primary.layer-off .readout-primary-title { color: #a6a6a6; }
-.map-section.layer-off .map-section-title { color: #a6a6a6; }
-.layer-off .units-pill { background: #bcbcbc; }
-.map-section.layer-off .map-section-chevron { border-color: #c4c4c4; }
+/* readout headers are NOT greyed when a layer is off -- the per-map toggle conveys on/off on its own */
 
 /* consolidated section: single column -- description, then a consistent resource grid */
 .readout-section-body { display: block; }

--- a/public/style.css
+++ b/public/style.css
@@ -1317,7 +1317,7 @@ p:last-child {
 .panel-tab.selected { background: #fff; color: #235c87; }
 .panel-tab.selected::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -1px; width: 44px; height: 2px; background: #326A98; border-radius: 2px; }
 /* #layersPanel now lives INSIDE #unitsPane: drop its absolute positioning so it flows as a pane */
-#unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; }
+#unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; flex: 1 1 auto; min-height: 0; }
 
 @media (max-width: 767px) {
     #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }

--- a/public/style.css
+++ b/public/style.css
@@ -1303,11 +1303,12 @@ p:last-child {
 .panel-tab.selected { background: #fff; color: #235c87; }
 .panel-tab.selected::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -1px; width: 44px; height: 2px; background: #326A98; border-radius: 2px; }
 /* #layersPanel now lives INSIDE #unitsPane: drop its absolute positioning so it flows as a pane */
-#unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; flex: 1 1 auto; min-height: 0; }
+#unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; flex: 1 1 auto; min-height: 0; background: transparent; }
 
 /* Layers tab rows: reuse the readout's real .layer-switch-slider so they match the Identify side */
 .lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 13px 0 5px; }
-#unitsPane #layersPanel .map-layer { margin: 0; }
+#unitsPane #layersPanel .map-layer { margin: 0; background: transparent; border-radius: 0; }
+#unitsPane #layersPanel .map-layer:hover { background: #f4f7fb; filter: none; border-radius: 6px; }
 #unitsPane #layersPanel .lyr-row { display: flex; align-items: center; gap: 10px; padding: 7px 2px; cursor: pointer; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; }
 #unitsPane #layersPanel .lyr-row .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }
 #unitsPane #layersPanel .lyr-name { flex: 1; min-width: 0; }

--- a/public/style.css
+++ b/public/style.css
@@ -1318,6 +1318,20 @@ p:last-child {
 #unitsPane #layersPanel #fpScale { margin: 0; gap: 3px; flex-wrap: nowrap; }
 #unitsPane #layersPanel #fpScale .scale-btn { padding: 2px 6px; font-size: 10px; border-radius: 4px; line-height: 1.3; }
 
+/* Display group: opacity + auto show/hide, in the same card style as the layer rows */
+#unitsPane #layersPanel #displayGroup { padding: 8px 10px; }
+#unitsPane #layersPanel #displayGroup .disp-row { display: flex; align-items: center; gap: 9px; padding: 4px 0; cursor: default; }
+#unitsPane #layersPanel #displayGroup label.disp-row { cursor: pointer; }
+#unitsPane #layersPanel #displayGroup .disp-name { flex: 1; min-width: 0; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 13px; letter-spacing: .3px; color: #4a4a4a; }
+#unitsPane #layersPanel #displayGroup .disp-div { height: 1px; background: #e6e8ea; margin: 6px 0; }
+#unitsPane #layersPanel #displayGroup #autoScaleToggle { position: absolute; opacity: 0; width: 1px; height: 1px; }
+#unitsPane #layersPanel #displayGroup #autoScaleToggle:checked ~ .layer-switch-slider { background: #6396fc; }
+#unitsPane #layersPanel #displayGroup #autoScaleToggle:checked ~ .layer-switch-slider::after { transform: translateX(13px); }
+#unitsPane #layersPanel #displayGroup .disp-val { flex: none; font-size: 11px; color: #7a8794; width: 34px; text-align: right; }
+#unitsPane #layersPanel .op-range { flex: 1; -webkit-appearance: none; appearance: none; height: 4px; border-radius: 3px; background: #e3e3e3; cursor: pointer; }
+#unitsPane #layersPanel .op-range::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 14px; height: 14px; border-radius: 50%; background: #fff; border: 2px solid #326A98; box-shadow: 0 1px 3px rgba(0,0,0,.25); cursor: pointer; }
+#unitsPane #layersPanel .op-range::-moz-range-thumb { width: 14px; height: 14px; border-radius: 50%; background: #fff; border: 2px solid #326A98; box-shadow: 0 1px 3px rgba(0,0,0,.25); cursor: pointer; }
+
 .readout-empty { padding: 22px 8px; text-align: center; color: #8a8f94; font-style: italic; font-size: 13px; }
 
 @media (max-width: 767px) {

--- a/public/style.css
+++ b/public/style.css
@@ -1309,6 +1309,14 @@ p:last-child {
 #unitsPane #layersPanel .lyr-row .list_item:checked ~ .layer-switch-slider { background: #6396fc; }
 #unitsPane #layersPanel .lyr-row .list_item:checked ~ .layer-switch-slider::after { transform: translateX(13px); }
 #unitsPane #layersPanel .lyr-row .list_item:focus-visible ~ .layer-switch-slider { outline: 2px solid #6396fc; outline-offset: 2px; }
+/* footprints row: scale filters inline as compact badges; the slider (in a for= label) sits at the far right */
+#unitsPane #layersPanel .lyr-row .list_item:checked ~ .fp-slider .layer-switch-slider { background: #6396fc; }
+#unitsPane #layersPanel .lyr-row .list_item:checked ~ .fp-slider .layer-switch-slider::after { transform: translateX(13px); }
+#unitsPane #layersPanel .lyr-row .list_item:focus-visible ~ .fp-slider .layer-switch-slider { outline: 2px solid #6396fc; outline-offset: 2px; }
+#unitsPane #layersPanel #fpSurveyRow .lyr-name { flex: none; }
+#unitsPane #layersPanel #fpSurveyRow .fp-slider { flex: none; margin-left: auto; display: inline-flex; align-items: center; cursor: pointer; }
+#unitsPane #layersPanel #fpScale { margin: 0; gap: 3px; flex-wrap: nowrap; }
+#unitsPane #layersPanel #fpScale .scale-btn { padding: 2px 6px; font-size: 10px; border-radius: 4px; line-height: 1.3; }
 
 .readout-empty { padding: 22px 8px; text-align: center; color: #8a8f94; font-style: italic; font-size: 13px; }
 

--- a/public/style.css
+++ b/public/style.css
@@ -57,7 +57,7 @@ body,
     box-shadow: 0 8px 16px 0 rgb(0 0 0 / 20%), 0 6px 20px 0 rgb(0 0 0 / 19%);
 }
 
-/* footprints scale sub-row: light Refined-Light treatment, accent-blue when selected (matches .fp-seg-btn) */
+/* footprints scale sub-row: light Refined-Light treatment, accent-blue when selected */
 #fpScale .scale-btn {
     color: #235c87 !important;
     background-color: #f4f7fb !important;
@@ -69,12 +69,6 @@ body,
     border-color: #326A98 !important;
 }
 
-.footprints-control { margin-top: 6px; }
-.fp-label { font-size: 11px; font-weight: 700; letter-spacing: .4px; text-transform: uppercase; color: #4a4a4a; margin: 4px 0 6px; }
-.fp-seg { display: flex; border: 1px solid #cdd8e3; border-radius: 6px; overflow: hidden; }
-.fp-seg-btn { flex: 1; font: inherit; font-size: 11.5px; padding: 6px 4px; background: #f7f9fc; color: #4a6b85; border: none; border-right: 1px solid #dde5ec; cursor: pointer; }
-.fp-seg-btn:last-child { border-right: none; }
-.fp-seg-btn.selected { background: #326A98; color: #fff; font-weight: 700; }
 .fp-scale { margin-top: 8px; display: flex; gap: 4px; flex-wrap: wrap; }
 .fp-scale[hidden] { display: none; }
 
@@ -2074,3 +2068,10 @@ p:last-child {
 .res-tool { font-size: 11px; padding: 4px 9px; border: 1px solid #d4dde7; border-radius: 4px; background: #f5f6f8; color: #326A98; cursor: pointer; }
 .res-tool:hover { background: #eceff4; }
 .res-tool:active { background: #e2e7ee; }
+
+.extent-toggle { flex: none; display: inline-flex; align-items: center; gap: 5px; cursor: pointer; font-size: 11px; color: #326A98; user-select: none; }
+.extent-toggle input { position: absolute; opacity: 0; width: 1px; height: 1px; }
+.extent-slider { position: relative; flex: none; width: 26px; height: 15px; background: #c6c6c6; border-radius: 8px; }
+.extent-slider::after { content: ""; position: absolute; top: 2px; left: 2px; width: 11px; height: 11px; background: #fff; border-radius: 50%; box-shadow: 0 1px 2px rgba(0,0,0,.3); transition: transform .15s ease; }
+.extent-toggle input:checked + .extent-slider { background: #6396fc; }
+.extent-toggle input:checked + .extent-slider::after { transform: translateX(11px); }

--- a/public/style.css
+++ b/public/style.css
@@ -583,9 +583,6 @@ overflow-y: hidden;
 }
 
 #layersPanel  {
-    position: absolute;
-    top: 182px;
-    right: 54px;
     width: 225px;
     color: #ccc;
     font-family: "Bebas Neue Regular", Verdana, sans-serif;
@@ -596,7 +593,6 @@ overflow-y: hidden;
     padding-top: 6px;
     padding-bottom: 4px;
     border-radius: 2px;
-    z-index: 1;
 
 }
 
@@ -1315,6 +1311,13 @@ p:last-child {
 #udTab { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
 #dlTab { flex: none; }
 #unitsPane.hidden { display: none; }   /* beat the id-specificity of display:flex when hidden */
+
+.panel-tabs { display: flex; flex: none; border-bottom: 1px solid #ededed; margin: -2px 0 8px; }
+.panel-tab { flex: 1; font-family: "Bebas Neue Regular", Verdana, sans-serif; font-size: 15px; letter-spacing: .4px; padding: 7px 0; background: #f7f9fc; color: #7a8794; border: none; cursor: pointer; position: relative; }
+.panel-tab.selected { background: #fff; color: #235c87; }
+.panel-tab.selected::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -1px; width: 44px; height: 2px; background: #326A98; border-radius: 2px; }
+/* #layersPanel now lives INSIDE #unitsPane: drop its absolute positioning so it flows as a pane */
+#unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; }
 
 @media (max-width: 767px) {
     #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }

--- a/public/style.css
+++ b/public/style.css
@@ -1314,10 +1314,10 @@ p:last-child {
 /* Task 2: Refined-Light switch rows */
 .lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 12px 0 6px; }
 #unitsPane #layersPanel .map-layer { margin: 0; }
-#unitsPane #layersPanel .map-layer label { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; padding: 6px 2px; cursor: pointer; }
+#unitsPane #layersPanel .map-layer label { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 8px; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; padding: 6px 2px; cursor: pointer; }
 #unitsPane #layersPanel .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }   /* hide native checkbox */
 #unitsPane #layersPanel .list_item + label::after { content: ""; flex: none; width: 30px; height: 17px; border-radius: 9px; background: #c6c6c6; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); transition: background .15s ease; position: relative; }
-#unitsPane #layersPanel .list_item + label::before { content: ""; position: absolute; right: 4px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.3); transform: translateX(-13px); transition: transform .15s ease; z-index: 1; }
+#unitsPane #layersPanel .list_item + label::before { content: ""; position: absolute; top: 50%; margin-top: -6.5px; right: 4px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.3); transform: translateX(-13px); transition: transform .15s ease; z-index: 1; }
 #unitsPane #layersPanel .list_item:checked + label::after { background: #6396fc; }
 #unitsPane #layersPanel .list_item:checked + label::before { transform: translateX(0); }
 #unitsPane #layersPanel .list_item:focus-visible + label::after { outline: 2px solid #6396fc; outline-offset: 2px; }

--- a/public/style.css
+++ b/public/style.css
@@ -584,14 +584,6 @@ overflow-y: hidden;
 
 #layersPanel  {
     width: 225px;
-    color: #ccc;
-    font-family: "Bebas Neue Regular", Verdana, sans-serif;
-    /* font-family:  "Avenir LT W01 65 Medium", Arial, Helvetica, sans-serif !important;*/
-    font-size: 20px;
-    padding-left: 10px;
-    padding-right: 6px;
-    padding-top: 6px;
-    padding-bottom: 4px;
     border-radius: 2px;
 
 }
@@ -1318,6 +1310,17 @@ p:last-child {
 .panel-tab.selected::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -1px; width: 44px; height: 2px; background: #326A98; border-radius: 2px; }
 /* #layersPanel now lives INSIDE #unitsPane: drop its absolute positioning so it flows as a pane */
 #unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; flex: 1 1 auto; min-height: 0; }
+
+/* Task 2: Refined-Light switch rows */
+.lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 12px 0 6px; }
+#unitsPane #layersPanel .map-layer { margin: 0; }
+#unitsPane #layersPanel .map-layer label { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; padding: 6px 2px; cursor: pointer; }
+#unitsPane #layersPanel .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }   /* hide native checkbox */
+#unitsPane #layersPanel .list_item + label::after { content: ""; flex: none; width: 30px; height: 17px; border-radius: 9px; background: #c6c6c6; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); transition: background .15s ease; position: relative; }
+#unitsPane #layersPanel .list_item + label::before { content: ""; position: absolute; right: 4px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.3); transform: translateX(-13px); transition: transform .15s ease; z-index: 1; }
+#unitsPane #layersPanel .list_item:checked + label::after { background: #6396fc; }
+#unitsPane #layersPanel .list_item:checked + label::before { transform: translateX(0); }
+#unitsPane #layersPanel .list_item:focus-visible + label::after { outline: 2px solid #6396fc; outline-offset: 2px; }
 
 @media (max-width: 767px) {
     #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }

--- a/public/style.css
+++ b/public/style.css
@@ -1305,16 +1305,15 @@ p:last-child {
 /* #layersPanel now lives INSIDE #unitsPane: drop its absolute positioning so it flows as a pane */
 #unitsPane #layersPanel { position: static; top: auto; right: auto; width: auto; z-index: auto; padding: 0 2px; overflow-y: auto; flex: 1 1 auto; min-height: 0; }
 
-/* Task 2: Refined-Light switch rows */
-.lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 12px 0 6px; }
+/* Layers tab rows: reuse the readout's real .layer-switch-slider so they match the Identify side */
+.lyr-group { font-size: 10px; font-weight: 700; letter-spacing: .9px; text-transform: uppercase; color: #9aa0a6; margin: 13px 0 5px; }
 #unitsPane #layersPanel .map-layer { margin: 0; }
-#unitsPane #layersPanel .map-layer label { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 8px; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; padding: 6px 2px; cursor: pointer; }
-#unitsPane #layersPanel .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }   /* hide native checkbox */
-#unitsPane #layersPanel .list_item + label::after { content: ""; flex: none; width: 30px; height: 17px; border-radius: 9px; background: #c6c6c6; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); transition: background .15s ease; position: relative; }
-#unitsPane #layersPanel .list_item + label::before { content: ""; position: absolute; top: 50%; margin-top: -6.5px; right: 4px; width: 13px; height: 13px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.3); transform: translateX(-13px); transition: transform .15s ease; z-index: 1; }
-#unitsPane #layersPanel .list_item:checked + label::after { background: #6396fc; }
-#unitsPane #layersPanel .list_item:checked + label::before { transform: translateX(0); }
-#unitsPane #layersPanel .list_item:focus-visible + label::after { outline: 2px solid #6396fc; outline-offset: 2px; }
+#unitsPane #layersPanel .lyr-row { display: flex; align-items: center; gap: 10px; padding: 7px 2px; cursor: pointer; font-family: "Avenir Next W00","Helvetica Neue",Arial,sans-serif; font-size: 13px; color: #2f2f2f; }
+#unitsPane #layersPanel .lyr-row .list_item { position: absolute; opacity: 0; width: 1px; height: 1px; }
+#unitsPane #layersPanel .lyr-name { flex: 1; min-width: 0; }
+#unitsPane #layersPanel .lyr-row .list_item:checked ~ .layer-switch-slider { background: #6396fc; }
+#unitsPane #layersPanel .lyr-row .list_item:checked ~ .layer-switch-slider::after { transform: translateX(13px); }
+#unitsPane #layersPanel .lyr-row .list_item:focus-visible ~ .layer-switch-slider { outline: 2px solid #6396fc; outline-offset: 2px; }
 
 .readout-empty { padding: 22px 8px; text-align: center; color: #8a8f94; font-style: italic; font-size: 13px; }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1316,8 +1316,11 @@ p:last-child {
 #unitsPane #layersPanel .list_item:checked + label::before { transform: translateX(0); }
 #unitsPane #layersPanel .list_item:focus-visible + label::after { outline: 2px solid #6396fc; outline-offset: 2px; }
 
+.readout-empty { padding: 22px 8px; text-align: center; color: #8a8f94; font-style: italic; font-size: 13px; }
+
 @media (max-width: 767px) {
     #unitsPane { width: auto; left: 5px; right: 5px; max-height: 70vh; }
+    #unitsPane #layersPanel { max-height: 50vh; }
 }
 
 .unit-desc-title {


### PR DESCRIPTION
## Summary

Merges the standalone Layers panel and the click readout into ONE bottom-right "Map" panel with a **Layers / Identify** tab bar, in the readout's Refined-Light language - fixing the archaic, overlapping Layers panel and giving layer control a home that's available before a click.

- **Unified panel:** `#layersPanel` is relocated INSIDE `#unitsPane` (its id + inputs kept, so all layer wiring stays intact); a tab bar switches Layers / Identify. Click a map -> Identify; toolbar Layers button -> Layers; close collapses the whole panel.
- **Layers tab:** geology + reference checkboxes restyled as Refined-Light switches (scale-dependency / auto show-hide unchanged); a "Map footprints" survey toggle + scale filter.
- **Identify tab:** the readout, unchanged, plus an "Extent" toggle in its head (the rehomed "this map" outline).
- **Footprints split:** the #155 Off/This-map/All control becomes a survey boolean (Layers) + an extent boolean (Identify), reusing the same footprints layer / highlight / scale plumbing.
- **State:** first load collapsed, then remembers open/collapsed + last tab (localStorage).

Spec/plan: `docs/specs|plans/2026-06-11-unified-map-panel*`.

**Stacked on #155** (`feat/remove-map-downloads-mode`). Deferred to separate passes: reference layers -> basemap switcher; opacity stays its own flyout; geology scale-dependency model unchanged.

## Review

Built task-by-task (5 tasks); each passed spec + code review (fixes applied: open-path routing + Layers-pane scroll, switch-knob anchor, the `#fpSurvey`-vs-layer-iteration exclusion), plus a final holistic integration review (ready to merge). `node --check` + CSS brace balance pass. No automated UI tests in this repo.

## Test plan (manual, on the preview)

- [ ] First load -> panel collapsed; open Layers + reload -> restored; click a map + reload -> restored on Identify.
- [ ] Tabs: click map -> Identify (readout); toolbar Layers button -> Layers; flip back and forth (readout preserved).
- [ ] Layers switches toggle geology/reference layers AND stay in sync with the readout's per-map toggles; scale-dependency still auto show/hides on zoom; the Layers pane scrolls when long.
- [ ] **Map footprints** survey toggle -> footprints draw + scale filter thins them + scopes the click query. **Extent** toggle (Identify head) -> active sheet outlines, follows accordion sections, reverts on collapse, clears on close/off.
- [ ] Readout head (title + Extent + units pill + per-map toggle) doesn't crowd/wrap at narrow widths.
- [ ] Mobile bottom sheet: tabs + both panes usable; no clipping; no console errors.